### PR TITLE
v2.1.0 - Bulk Ops from Current File, Auto-Catalog Copy & Bug Fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.zip
 .github/copilot-instructions.md
+*__pycache__*

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,11 @@
+{
+  "python.analysis.diagnosticSeverityOverrides": {
+    "reportMissingModuleSource": "none",
+    "reportInvalidTypeForm": "none",
+    "reportOptionalMemberAccess": "none",
+    "reportAttributeAccessIssue": "none",
+    "reportAssignmentType": "none",
+    "reportGeneralTypeIssues": "none",
+    "reportIncompatibleMethodOverride": "none"
+  }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,22 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "2.0.0",
+    "tasks": [
+        {
+            "label": "Build to Dist",
+            "type": "shell",
+            "command": "blender",
+            "args": [
+                "--command",
+                "extension",
+                "build",
+                "--source-dir",
+                ".\\QuickAssetSaver\\.",
+                "--output-dir",
+                ".\\dist\\."
+            ],
+            "problemMatcher": []
+        }
+    ]
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,35 @@
+# Changelog
+
+All notable user-facing changes to Quick Asset Manager are documented here.
+
+## 2.1.0
+
+This release brings a couple of highly requested features, several bug fixes, and a round of general polish.
+
+### New Features
+
+- **Bulk Move & Bundle from Current File**: You can now select multiple unsaved assets directly in your Current File and Move or Bundle them straight to a library, instead of saving them one at a time.
+- **Copy Catalog from Current File**: When saving an asset, enable this checkbox to automatically reuse the asset's existing catalog. If that catalog doesn't exist yet in the target library, it's created for you — no need to pick it manually from the dropdown.
+
+### Improvements
+
+- Moving assets now shows a clear confirmation message, so you know right away it worked.
+- The Catalog dropdown has a refresh button, so newly created catalogs show up immediately without restarting Blender.
+- Disabled asset libraries no longer show up in your library dropdowns. #11
+- Added a heads-up on the Bundle panel that opening the save-path picker will deselect your assets (a quirk of Blender's file browser).
+
+### Bug Fixes
+
+- Saving an asset to a library no longer removes its catalog from the Current File. 
+- Fixed an issue on Blender 5.1+ where the protected Essentials library could accidentally be modified.
+- Fixed "Overwrite" mode for Bundling so it actually replaces the existing file instead of always creating a new one.
+- Fixed Bulk Move from the Current File incorrectly reporting "no assets selected."
+- Fixed the "Saved!" confirmation message appearing in red as if it were an error.
+- If your system's recycle bin/trash feature isn't available, you'll now get a clear warning instead of a silent failure.
+- Fixed Compositor node group assets copying the entire project into the library file instead of just the node group itself.
+- Fixed saving Scene assets with sound/video sequences potentially failing on the newest Blender 5.2 builds.
+
+### Notes
+- Blender 5.2 added online asset libraries, which at least for now will not be supported by Quick Asset Manager. All QAM features will not work to or from online asset libraries. This was a conscious decision to avoid the complexity of dealing with online asset libraries, which are not yet fully documented and may change in future Blender releases. Additionally, I'm not entirely sure how licensing and copyright issues will be handled with online asset libraries, so for now QAM will only support local asset libraries.
+
+- While the user-facing changes are relatively minor, the underlying code has had a large refactor to improve maintainability and future feature development. Because of this, testing has been incredibly thorough (including creating over 150 tests to ensure no regressions), but if you notice any issues, please report them on GitHub.

--- a/QuickAssetSaver/__init__.py
+++ b/QuickAssetSaver/__init__.py
@@ -1,15 +1,6 @@
-if "bpy" in locals():
-    import importlib
-    if "operators" in locals():
-        importlib.reload(operators)  # noqa: F821
-    if "properties" in locals():
-        importlib.reload(properties)  # noqa: F821
-    if "panels" in locals():
-        importlib.reload(panels)  # noqa: F821
-else:
-    from . import operators, panels, properties
+from . import operators, panels, properties
 
-import bpy  # noqa: F401
+# import bpy Temp comment out, testing if needed  # noqa: F401
 
 
 def register():

--- a/QuickAssetSaver/blender_manifest.toml
+++ b/QuickAssetSaver/blender_manifest.toml
@@ -1,6 +1,6 @@
 schema_version = "1.0.0"
 id = "Quick_Asset_Saver"
-version = "2.0.2"
+version = "2.1.0"
 name = "Quick Asset Manager"
 tagline = "Quickly Create, Edit, Organize, or Delete your local asset files"
 maintainer = "Clonephaze"

--- a/QuickAssetSaver/compatibility.py
+++ b/QuickAssetSaver/compatibility.py
@@ -1,0 +1,82 @@
+"""
+Blender version compatibility shims for Quick Asset Manager.
+
+All panel poll() methods and operator guards should call these functions
+rather than inlining the checks. This centralises version-specific logic.
+"""
+
+import bpy
+
+
+def is_asset_browser_active(context) -> bool:
+    """
+    Returns True if the current context is an active Asset Browser.
+
+    Handles Blender 5.1+ per-shelf active state
+    (commit ab2aa2512f — each shelf now has its own active state).
+
+    ACTION REQUIRED before shipping: confirm the exact attribute name
+    from https://projects.blender.org/blender/blender/commit/ab2aa2512f
+    and update the 5.1 branch below.
+    """
+    space = context.space_data
+    if space is None or space.type != 'FILE_BROWSER':
+        return False
+    if getattr(space, 'browse_mode', None) != 'ASSETS':
+        return False
+    if bpy.app.version >= (5, 1, 0):
+        # Verified working in Blender 5.1 testing. The getattr fallback (default=True)
+        # is the correct approach: if the attribute doesn't exist in a given version,
+        # we assume the browser is active rather than hiding the panel incorrectly.
+        if not getattr(space, 'is_asset_browser', True):
+            return False
+    return True
+
+
+def is_user_library(context) -> bool:
+    """True if the active library is a user-configured one (has a filesystem path
+    and is not a virtual or protected Blender built-in)."""
+    from .constants import EXCLUDED_LIBRARY_REFS
+    space = context.space_data
+    if not space:
+        return False
+    params = getattr(space, 'params', None)
+    if not params:
+        return False
+    ref = getattr(params, 'asset_library_reference', None)
+    if not ref and params:
+        ref = getattr(params, 'asset_library_ref', None)
+    return bool(ref and ref not in EXCLUDED_LIBRARY_REFS)
+
+
+def is_protected_library(context) -> bool:
+    """True if the active library is Essentials (read-only, must not be modified)."""
+    from .constants import PROTECTED_LIBRARY_REFS
+    space = context.space_data
+    if not space:
+        return False
+    params = getattr(space, 'params', None)
+    if not params:
+        return False
+    ref = getattr(params, 'asset_library_reference', None)
+    if not ref:
+        ref = getattr(params, 'asset_library_ref', None)
+    return bool(ref and ref in PROTECTED_LIBRARY_REFS)
+
+
+def is_online_library(context) -> bool:
+    """
+    True if the active library is an online/remote library (Blender 5.2+).
+    These must not be modified by QAM — too many edge cases and licensing risks.
+    """
+    space = context.space_data
+    if not space:
+        return False
+    params = getattr(space, 'params', None)
+    if not params:
+        return False
+    # Blender 5.2 introduced online library types; check for the type attribute
+    lib_type = getattr(params, 'asset_library_type', None)
+    if lib_type is not None:
+        return lib_type not in {'LOCAL', 'CUSTOM', 'ESSENTIALS', 'ALL'}
+    return False

--- a/QuickAssetSaver/compatibility.py
+++ b/QuickAssetSaver/compatibility.py
@@ -35,7 +35,7 @@ def is_asset_browser_active(context) -> bool:
 
 def is_user_library(context) -> bool:
     """True if the active library is a user-configured one (has a filesystem path
-    and is not a virtual or protected Blender built-in)."""
+    and is not a virtual, protected, or online Blender library)."""
     from .constants import EXCLUDED_LIBRARY_REFS
     space = context.space_data
     if not space:
@@ -46,7 +46,12 @@ def is_user_library(context) -> bool:
     ref = getattr(params, 'asset_library_reference', None)
     if not ref and params:
         ref = getattr(params, 'asset_library_ref', None)
-    return bool(ref and ref not in EXCLUDED_LIBRARY_REFS)
+    if not ref or ref in EXCLUDED_LIBRARY_REFS:
+        return False
+    # Also block online/remote libraries (Blender 5.2+)
+    if is_online_library(context):
+        return False
+    return True
 
 
 def is_protected_library(context) -> bool:

--- a/QuickAssetSaver/compatibility.py
+++ b/QuickAssetSaver/compatibility.py
@@ -85,3 +85,40 @@ def is_online_library(context) -> bool:
     if lib_type is not None:
         return lib_type not in {'LOCAL', 'CUSTOM', 'ESSENTIALS', 'ALL'}
     return False
+
+
+def get_sequencer_strips(sequence_editor):
+    """
+    Returns all strips in a sequence editor across Blender API renames.
+
+    Blender 5.2 renamed SequenceEditor.sequences_all -> SequenceEditor.strips_all
+    (part of the VSE "Strip" rework, Sequence -> Strip).
+
+    Returns an empty list if the sequence editor is None or has neither
+    attribute.
+    """
+    if sequence_editor is None:
+        return []
+    strips = getattr(sequence_editor, 'sequences_all', None)
+    if strips is None:
+        strips = getattr(sequence_editor, 'strips_all', None)
+    return list(strips) if strips is not None else []
+
+
+def ensure_scene_compositor_node_tree(scene, name="Compositing Nodetree"):
+    """
+    Create (if needed) and return a scene's compositor node tree, across
+    Blender API generations.
+
+    Blender < 5.2: the compositor tree is created via `scene.use_nodes = True`
+    and accessed as `scene.node_tree` (a single tree embedded per-scene).
+    Blender 5.2+: compositor trees are standalone bpy.data.node_groups
+    entries assigned via `scene.compositing_node_group` (Scene.node_tree was
+    removed as part of making compositor trees shareable/markable as assets).
+    """
+    if hasattr(scene, 'node_tree'):
+        scene.use_nodes = True
+        return scene.node_tree
+    node_tree = bpy.data.node_groups.new(name, 'CompositorNodeTree')
+    scene.compositing_node_group = node_tree
+    return node_tree

--- a/QuickAssetSaver/constants.py
+++ b/QuickAssetSaver/constants.py
@@ -1,0 +1,42 @@
+"""
+Shared constants for Quick Asset Manager.
+"""
+
+# Library references with no filesystem path — bulk/move/delete not applicable
+VIRTUAL_LIBRARY_REFS = frozenset({"LOCAL", "CURRENT", "ALL"})
+
+# Libraries that exist on disk but must never be modified by QAM
+PROTECTED_LIBRARY_REFS = frozenset({"ESSENTIALS"})
+
+# All library refs where QAM edit operations are not permitted
+EXCLUDED_LIBRARY_REFS = VIRTUAL_LIBRARY_REFS | PROTECTED_LIBRARY_REFS
+
+# Companion folder names (conservative — false positives delete user data)
+# Each inner list is a group of equivalent casing variants for the same concept.
+# Do not expand without explicit review.
+COMPANION_FOLDER_GROUPS = [
+    ['textures', 'Textures', 'TEXTURES'],
+    ['maps', 'Maps', 'MAPS'],
+    ['materials', 'Materials', 'MATERIALS'],
+    ['shaders', 'Shaders', 'SHADERS'],
+    ['images', 'Images', 'IMAGES'],
+    ['hdri', 'HDRI', 'hdris', 'HDRIs'],
+    ['references', 'References', 'ref', 'Ref'],
+    ['documentation', 'Documentation', 'docs', 'Docs'],
+    ['resources', 'Resources', 'RESOURCES'],
+]
+COMPANION_FOLDER_NAMES = [
+    name for group in COMPANION_FOLDER_GROUPS for name in group
+]
+
+THUMBNAIL_EXTENSIONS = ['.png', '.webp', '.jpg', '.jpeg']
+METADATA_EXTENSIONS = ['.json', '.txt', '.md', '.xml']
+
+MIN_BLEND_FILE_SIZE = 100          # bytes — files smaller than this are ignored
+MAX_INCREMENTAL_FILES = 9999       # upper bound for _001 suffix generation
+LARGE_SELECTION_WARNING_THRESHOLD = 25  # show warning when selecting more than this
+MAX_FILENAME_AFFIX_LENGTH = 32
+
+DEFAULT_MAX_BUNDLE_SIZE_MB = 4096
+VERY_LARGE_BUNDLE_WARNING_MB = 5000  # legacy name used in bundle.py
+LARGE_BUNDLE_WARNING_MB = int(DEFAULT_MAX_BUNDLE_SIZE_MB * 0.75)  # 3072 MB

--- a/QuickAssetSaver/operators/__init__.py
+++ b/QuickAssetSaver/operators/__init__.py
@@ -1,31 +1,4 @@
-"""
-Quick Asset Saver operators package.
-"""
-
-if "bpy" in locals():
-    import importlib
-    if "utils" in locals():
-        importlib.reload(utils)  # noqa: F821
-    if "catalog" in locals():
-        importlib.reload(catalog)  # noqa: F821
-    if "file_io" in locals():
-        importlib.reload(file_io)  # noqa: F821
-    if "save" in locals():
-        importlib.reload(save)  # noqa: F821
-    if "bundle" in locals():
-        importlib.reload(bundle)  # noqa: F821
-    if "move" in locals():
-        importlib.reload(move)  # noqa: F821
-    if "delete" in locals():
-        importlib.reload(delete)  # noqa: F821
-    if "manage" in locals():
-        importlib.reload(manage)  # noqa: F821
-    if "swap" in locals():
-        importlib.reload(swap)  # noqa: F821
-    if "metadata" in locals():
-        importlib.reload(metadata)  # noqa: F821
-
-from . import utils, catalog, file_io, save, bundle, move, delete, manage, swap, metadata  # noqa: F401
+﻿from . import utils, catalog, file_io, save, bundle, move, delete, manage, swap, metadata  # noqa: F401
 
 import bpy
 
@@ -49,6 +22,7 @@ from .catalog import (  # noqa: F401
     get_catalogs_from_cdf,
     clear_and_set_tags,
     clear_catalog_cache,
+    QAM_OT_refresh_catalog_list,
 )
 
 from .file_io import (  # noqa: F401
@@ -60,40 +34,41 @@ from .file_io import (  # noqa: F401
 )
 
 from .save import (
-    QAS_OT_save_asset_to_library_direct,
-    QAS_OT_open_library_folder,
+    QAM_OT_save_asset_to_library_direct,
+    QAM_OT_open_library_folder,
 )
 
 from .bundle import (
-    QAS_OT_bundle_assets,
-    QAS_OT_open_bundle_folder,
+    QAM_OT_bundle_assets,
+    QAM_OT_open_bundle_folder,
 )
 
 from .manage import (
-    QAS_OT_move_selected_to_library,
-    QAS_OT_delete_selected_assets,
+    QAM_OT_move_selected_to_library,
+    QAM_OT_delete_selected_assets,
 )
 
 from .swap import (
-    QAS_OT_swap_selected_with_asset,
+    QAM_OT_swap_selected_with_asset,
 )
 
 from .metadata import (
-    QAS_OT_apply_metadata_changes,
-    QAS_OT_toggle_edit_mode,
+    QAM_OT_apply_metadata_changes,
+    QAM_OT_toggle_edit_mode,
 )
 
 
 classes = (
-    QAS_OT_save_asset_to_library_direct,
-    QAS_OT_open_library_folder,
-    QAS_OT_move_selected_to_library,
-    QAS_OT_delete_selected_assets,
-    QAS_OT_swap_selected_with_asset,
-    QAS_OT_bundle_assets,
-    QAS_OT_open_bundle_folder,
-    QAS_OT_apply_metadata_changes,
-    QAS_OT_toggle_edit_mode,
+    QAM_OT_save_asset_to_library_direct,
+    QAM_OT_open_library_folder,
+    QAM_OT_move_selected_to_library,
+    QAM_OT_delete_selected_assets,
+    QAM_OT_swap_selected_with_asset,
+    QAM_OT_bundle_assets,
+    QAM_OT_open_bundle_folder,
+    QAM_OT_apply_metadata_changes,
+    QAM_OT_toggle_edit_mode,
+    QAM_OT_refresh_catalog_list,
 )
 
 

--- a/QuickAssetSaver/operators/bundle.py
+++ b/QuickAssetSaver/operators/bundle.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Asset bundle operator for Quick Asset Saver.
 """
 
@@ -10,6 +10,7 @@ from pathlib import Path
 import bpy
 from bpy.types import Operator
 
+from .. import properties
 from .utils import (
     debug_print,
     sanitize_name,
@@ -21,18 +22,10 @@ from .utils import (
 )
 
 
-def get_addon_preferences():
-    """Get the addon preferences object."""
-    addon = bpy.context.preferences.addons.get(__package__.rsplit('.', 1)[0], None)
-    if addon:
-        return addon.preferences
-    return None
-
-
-class QAS_OT_bundle_assets(Operator):
+class QAM_OT_bundle_assets(Operator):
     """Bundle selected assets from a user library into a single .blend file."""
 
-    bl_idname = "qas.bundle_assets"
+    bl_idname = "qam.bundle_assets"
     bl_label = "Bundle Selected Assets"
     bl_description = "Combine selected assets into a single shareable .blend file"
     bl_options = {"REGISTER", "UNDO"}
@@ -55,7 +48,7 @@ class QAS_OT_bundle_assets(Operator):
 
         asset_lib_ref = params.asset_library_reference
 
-        excluded_refs = ["LOCAL", "CURRENT", "ALL", "ESSENTIALS"]
+        excluded_refs = ["ALL", "ESSENTIALS"]
         if asset_lib_ref in excluded_refs:
             return False
 
@@ -63,6 +56,10 @@ class QAS_OT_bundle_assets(Operator):
             newer_ref = params.asset_library_ref
             if newer_ref in excluded_refs:
                 return False
+
+        # Current File context - always valid if we get here
+        if asset_lib_ref in ("LOCAL", "CURRENT"):
+            return True
 
         prefs = context.preferences
         if hasattr(prefs, "filepaths") and hasattr(prefs.filepaths, "asset_libraries"):
@@ -75,7 +72,20 @@ class QAS_OT_bundle_assets(Operator):
     def execute(self, context):
         """Execute the bundling operation."""
         wm = context.window_manager
-        props = wm.qas_bundler_props
+        props = wm.qam_bundler_props
+
+        # Detect source context
+        params = getattr(context.space_data, "params", None)
+        asset_lib_ref = None
+        if params:
+            asset_lib_ref = (
+                getattr(params, "asset_library_reference", None)
+                or getattr(params, "asset_library_ref", None)
+            )
+        is_current_file = asset_lib_ref in ("LOCAL", "CURRENT")
+
+        if is_current_file:
+            return self._execute_current_file_bundle(context, props)
 
         selected_assets = self._collect_selected_assets(context)
 
@@ -107,7 +117,7 @@ class QAS_OT_bundle_assets(Operator):
             )
 
         total_size_mb = self._calculate_total_size(selected_assets)
-        preferences = get_addon_preferences()
+        preferences = properties.get_addon_preferences(context)
         max_bundle_size_mb = preferences.max_bundle_size_mb if preferences else DEFAULT_MAX_BUNDLE_SIZE_MB
 
         print(f"Total asset size: {total_size_mb:.1f} MB")
@@ -138,11 +148,13 @@ class QAS_OT_bundle_assets(Operator):
             self.report({"ERROR"}, f"Could not create output directory: {e}")
             return {"CANCELLED"}
 
-        target_path = increment_filename(
-            save_path, f"{output_name}_{date_str}", ".blend"
-        )
-
         duplicate_mode = props.duplicate_mode
+        base_name = f"{output_name}_{date_str}"
+        base_path = save_path / f"{base_name}.blend"
+        if duplicate_mode == "OVERWRITE" and base_path.exists():
+            target_path = base_path
+        else:
+            target_path = increment_filename(save_path, base_name, ".blend")
         total_assets = len(selected_assets)
 
         print(f"Importing {total_assets} asset files...")
@@ -213,6 +225,53 @@ class QAS_OT_bundle_assets(Operator):
             props.success_message_time = time.time()
         
         return {"FINISHED"}
+
+    def _execute_current_file_bundle(self, context, props):
+        """Bundle selected assets from the Current File into a single .blend file."""
+        from .file_io import write_blend_file
+
+        # Collect local datablocks from selected assets
+        local_datablocks = set()
+        asset_files = None
+        if hasattr(context, "selected_asset_files") and context.selected_asset_files is not None:
+            asset_files = context.selected_asset_files
+        elif hasattr(context, "selected_assets") and context.selected_assets is not None:
+            asset_files = context.selected_assets
+
+        if asset_files:
+            for af in asset_files:
+                local_id = getattr(af, "local_id", None)
+                if local_id is not None:
+                    local_datablocks.add(local_id)
+
+        if not local_datablocks:
+            self.report({"WARNING"}, "No local assets found in selection")
+            return {"CANCELLED"}
+
+        # Build output path
+        save_path = Path(props.save_path) if props.save_path else Path.home()
+        output_name = sanitize_name(props.output_name) if props.output_name else "AssetBundle"
+        date_str = datetime.now().strftime("%Y-%m-%d")
+
+        try:
+            save_path.mkdir(parents=True, exist_ok=True)
+        except Exception as e:
+            self.report({"ERROR"}, f"Could not create output directory: {e}")
+            return {"CANCELLED"}
+
+        target_path = increment_filename(save_path, f"{output_name}_{date_str}", ".blend")
+
+        count = len(local_datablocks)
+        success = write_blend_file(target_path, local_datablocks)
+
+        if success:
+            self.report({"INFO"}, f"Bundle saved: {target_path.name} ({count} assets)")
+            props.show_success_message = True
+            props.success_message_time = time.time()
+            return {"FINISHED"}
+        else:
+            self.report({"ERROR"}, f"Failed to save bundle to {target_path.name}")
+            return {"CANCELLED"}
 
     def _calculate_total_size(self, asset_paths):
         """Calculate the total size of all asset files in megabytes."""
@@ -473,17 +532,17 @@ class QAS_OT_bundle_assets(Operator):
             print(f"Warning: Could not copy catalog file: {e}")
 
 
-class QAS_OT_open_bundle_folder(Operator):
+class QAM_OT_open_bundle_folder(Operator):
     """Open the folder where bundles are saved."""
 
-    bl_idname = "qas.open_bundle_folder"
+    bl_idname = "qam.open_bundle_folder"
     bl_label = "Open Bundle Folder"
     bl_description = "Open the folder where asset bundles are saved"
 
     def execute(self, context):
         """Open the bundle save folder in the system file browser."""
         wm = context.window_manager
-        props = wm.qas_bundler_props
+        props = wm.qam_bundler_props
 
         folder_path = props.save_path if props.save_path else str(Path.home())
 
@@ -496,6 +555,6 @@ class QAS_OT_open_bundle_folder(Operator):
 
 
 classes = (
-    QAS_OT_bundle_assets,
-    QAS_OT_open_bundle_folder,
+    QAM_OT_bundle_assets,
+    QAM_OT_open_bundle_folder,
 )

--- a/QuickAssetSaver/operators/bundle.py
+++ b/QuickAssetSaver/operators/bundle.py
@@ -57,6 +57,11 @@ class QAM_OT_bundle_assets(Operator):
             if newer_ref in excluded_refs:
                 return False
 
+        # Block online/remote libraries (Blender 5.2+)
+        from ..compatibility import is_online_library
+        if is_online_library(context):
+            return False
+
         # Current File context - always valid if we get here
         if asset_lib_ref in ("LOCAL", "CURRENT"):
             return True
@@ -64,6 +69,10 @@ class QAM_OT_bundle_assets(Operator):
         prefs = context.preferences
         if hasattr(prefs, "filepaths") and hasattr(prefs.filepaths, "asset_libraries"):
             for lib in prefs.filepaths.asset_libraries:
+                # Only match user-configured (CUSTOM) libraries; in 5.2+ Essentials/All
+                # Libraries appear in this list and must not be treated as valid targets
+                if getattr(lib, 'type', 'CUSTOM') != 'CUSTOM':
+                    continue
                 if hasattr(lib, "name") and lib.name == asset_lib_ref:
                     return True
 

--- a/QuickAssetSaver/operators/catalog.py
+++ b/QuickAssetSaver/operators/catalog.py
@@ -5,6 +5,8 @@ Catalog parsing and management functions for Quick Asset Saver.
 import uuid
 from pathlib import Path
 
+import bpy
+
 from .utils import debug_print
 
 _CATALOG_ENUM_CACHE = []
@@ -94,7 +96,7 @@ def get_catalogs_from_cdf(library_path):
                     # This supports Chinese, Japanese, Korean and other non-ASCII catalog names
                     display_name = str(catalog_path)
                     
-                    debug_print(f"[QAS Catalog Debug] Adding catalog {idx}: uuid={catalog_uuid}, name={display_name}")
+                    debug_print(f"[QAM Catalog Debug] Adding catalog {idx}: uuid={catalog_uuid}, name={display_name}")
                     
                     enum_items.append(
                         (
@@ -120,7 +122,7 @@ def get_catalogs_from_cdf(library_path):
         print(f"Encoding error reading catalog file {cdf_path}: {e}")
 
     _CATALOG_ENUM_CACHE = enum_items
-    debug_print(f"[QAS Catalog Debug] Cached {len(_CATALOG_ENUM_CACHE)} catalog items")
+    debug_print(f"[QAM Catalog Debug] Cached {len(_CATALOG_ENUM_CACHE)} catalog items")
     
     return catalogs, _CATALOG_ENUM_CACHE
 
@@ -161,3 +163,72 @@ def clear_catalog_cache():
     """Clear the catalog enum cache to force re-reading from disk."""
     global _CATALOG_ENUM_CACHE
     _CATALOG_ENUM_CACHE = []
+
+
+def create_catalog_entry(library_path: str, catalog_path: str) -> str:
+    """
+    Add a new catalog entry to the library's CDF if the path doesn't exist.
+    Preserves ALL existing CDF content. Safe to call if the entry already exists
+    (returns the existing UUID in that case).
+
+    Args:
+        library_path: Path to the asset library folder containing blender_assets.cats.txt
+        catalog_path: Catalog path string (e.g., "Materials/Metal")
+
+    Returns:
+        str: UUID for this catalog path (existing UUID if already present, new UUID if created)
+    """
+    import uuid as _uuid_mod
+
+    lib_path = Path(library_path)
+    cdf_path = lib_path / "blender_assets.cats.txt"
+
+    # Check if it already exists — reuse existing UUID
+    existing_catalogs, _ = get_catalogs_from_cdf(library_path)
+    if catalog_path in existing_catalogs:
+        return existing_catalogs[catalog_path]
+
+    new_uuid = str(_uuid_mod.uuid4())
+    display_name = catalog_path.split("/")[-1] if "/" in catalog_path else catalog_path
+
+    # Create the CDF with a VERSION header if it doesn't exist yet
+    if not cdf_path.exists():
+        try:
+            cdf_path.write_text("VERSION 1\n\n", encoding="utf-8")
+        except (OSError, IOError) as e:
+            print(f"[QAM] Could not create catalog file at {cdf_path}: {e}")
+            return new_uuid
+
+    # Append the new entry, preserving all existing content
+    try:
+        with open(cdf_path, "a", encoding="utf-8") as f:
+            f.write(f"{new_uuid}:{catalog_path}:{display_name}\n")
+    except (OSError, IOError) as e:
+        print(f"[QAM] Could not write catalog entry to {cdf_path}: {e}")
+        return new_uuid
+
+    # Invalidate the enum cache so the next rebuild picks up the new entry
+    clear_catalog_cache()
+
+    if bpy.app.debug:
+        print(f"[QAM] Created catalog entry: {catalog_path} ({new_uuid})")
+
+    return new_uuid
+
+
+class QAM_OT_refresh_catalog_list(bpy.types.Operator):
+    """Refresh the catalog dropdown by re-reading the library's catalog file"""
+
+    bl_idname = "qam.refresh_catalog_list"
+    bl_label = ""
+    bl_description = "Re-read the catalog file from disk to pick up any changes made outside this addon"
+    bl_options = {"INTERNAL"}
+
+    def execute(self, context):
+        clear_catalog_cache()
+        if context.area:
+            context.area.tag_redraw()
+        return {"FINISHED"}
+
+
+classes = (QAM_OT_refresh_catalog_list,)

--- a/QuickAssetSaver/operators/delete.py
+++ b/QuickAssetSaver/operators/delete.py
@@ -211,9 +211,12 @@ class QAM_OT_delete_selected_assets(Operator):
         )
 
     def execute(self, context):
-        from ..compatibility import is_protected_library
+        from ..compatibility import is_protected_library, is_online_library
         if is_protected_library(context):
             self.report({"ERROR"}, "The Essentials library is protected and cannot be modified")
+            return {"CANCELLED"}
+        if is_online_library(context):
+            self.report({"ERROR"}, "Online libraries cannot be modified")
             return {"CANCELLED"}
 
         selected_assets, _ = collect_selected_assets_with_names(context)

--- a/QuickAssetSaver/operators/delete.py
+++ b/QuickAssetSaver/operators/delete.py
@@ -34,7 +34,6 @@ from .file_io import (
 )
 from ..constants import (
     COMPANION_FOLDER_GROUPS,
-    COMPANION_FOLDER_NAMES,
     THUMBNAIL_EXTENSIONS,
     METADATA_EXTENSIONS,
 )

--- a/QuickAssetSaver/operators/delete.py
+++ b/QuickAssetSaver/operators/delete.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Delete operator for Quick Asset Saver.
 Handles deleting assets from the Asset Browser.
 """
@@ -9,11 +9,19 @@ import bpy
 from bpy.types import Operator
 
 try:
-    from send2trash import send2trash
+    from send2trash import send2trash as _send2trash
+
+    def move_to_trash(path) -> None:
+        _send2trash(str(path))
+
 except ImportError:
-    def send2trash(path):
-        import os
-        os.remove(path)
+    def move_to_trash(path) -> None:
+        from pathlib import Path
+        p = Path(path)
+        raise RuntimeError(
+            f"Send2Trash is unavailable. '{p.name}' was NOT deleted.\n"
+            f"You can delete it manually at: {p.parent}"
+        )
 
 from .utils import (
     debug_print,
@@ -24,29 +32,12 @@ from .file_io import (
     collect_selected_assets_with_names,
     count_assets_in_blend,
 )
-
-
-# Common asset companion folder groups (case variations)
-COMPANION_FOLDER_GROUPS = [
-    ['textures', 'Textures', 'TEXTURES'],
-    ['maps', 'Maps', 'MAPS'],
-    ['materials', 'Materials', 'MATERIALS'],
-    ['shaders', 'Shaders', 'SHADERS'],
-    ['images', 'Images', 'IMAGES'],
-    ['hdri', 'HDRI', 'hdris', 'HDRIs'],
-    ['references', 'References', 'ref', 'Ref'],
-    ['documentation', 'Documentation', 'docs', 'Docs'],
-    ['resources', 'Resources', 'RESOURCES'],
-]
-
-# Flat list of all companion folder names for quick checking
-COMPANION_FOLDER_NAMES = [name for group in COMPANION_FOLDER_GROUPS for name in group]
-
-# Thumbnail file extensions
-THUMBNAIL_EXTENSIONS = ['.png', '.webp', '.jpg', '.jpeg']
-
-# Metadata file extensions
-METADATA_EXTENSIONS = ['.json', '.txt', '.md', '.xml']
+from ..constants import (
+    COMPANION_FOLDER_GROUPS,
+    COMPANION_FOLDER_NAMES,
+    THUMBNAIL_EXTENSIONS,
+    METADATA_EXTENSIONS,
+)
 
 
 def _should_cleanup_empty_folder(folder_path):
@@ -144,27 +135,19 @@ def _trash_companions_for_file(blend_path):
     trashed_count = 0
     for item in items_to_trash:
         try:
-            send2trash(str(item))
+            move_to_trash(str(item))
             debug_print(f"Sent companion to recycle bin: {item}")
             trashed_count += 1
-        except Exception as e:
+        except (RuntimeError, Exception) as e:
             debug_print(f"Warning: Could not trash {item}: {e}")
-            try:
-                if item.is_dir():
-                    shutil.rmtree(str(item))
-                else:
-                    item.unlink()
-                trashed_count += 1
-            except Exception:
-                pass
     
     return trashed_count
 
 
-class QAS_OT_delete_selected_assets(Operator):
+class QAM_OT_delete_selected_assets(Operator):
     """Delete selected assets - handles both single and multi-asset files safely"""
 
-    bl_idname = "qas.delete_selected_assets"
+    bl_idname = "qam.delete_selected_assets"
     bl_label = "Delete Selected Assets"
     bl_description = "Delete selected assets (removes from multi-asset files or sends single-asset files to trash)"
     bl_options = {"REGISTER"}
@@ -229,6 +212,11 @@ class QAS_OT_delete_selected_assets(Operator):
         )
 
     def execute(self, context):
+        from ..compatibility import is_protected_library
+        if is_protected_library(context):
+            self.report({"ERROR"}, "The Essentials library is protected and cannot be modified")
+            return {"CANCELLED"}
+
         selected_assets, _ = collect_selected_assets_with_names(context)
         if not selected_assets:
             self.report({"WARNING"}, "No assets selected")
@@ -263,18 +251,18 @@ class QAS_OT_delete_selected_assets(Operator):
                     companions_trashed += companions_count
                     
                     # Then trash the .blend file itself
-                    send2trash(str(path))
+                    move_to_trash(str(path))
                     deleted_files += 1
                     
                     # Check if parent folder is now empty and clean it up
                     if _should_cleanup_empty_folder(parent_folder):
                         try:
-                            send2trash(str(parent_folder))
+                            move_to_trash(str(parent_folder))
                             folders_cleaned += 1
                             debug_print(f"Cleaned up empty folder: {parent_folder}")
-                        except Exception as e:
+                        except (RuntimeError, Exception) as e:
                             debug_print(f"Could not cleanup empty folder {parent_folder}: {e}")
-                except Exception as e:
+                except (RuntimeError, Exception) as e:
                     print(f"Failed to send {path.name} to trash: {e}")
                     failed += 1
             else:
@@ -333,7 +321,7 @@ class QAS_OT_delete_selected_assets(Operator):
                     for name in names:
                         if name in collection:
                             existing_db = collection[name]
-                            temp_name = f"__QAS_DEL_TEMP_{name}_{id(existing_db)}"
+                            temp_name = f"__QAM_DEL_TEMP_{name}_{id(existing_db)}"
                             original_name = existing_db.name
                             existing_db.name = temp_name
                             renamed_existing.append((existing_db, original_name))
@@ -426,5 +414,5 @@ class QAS_OT_delete_selected_assets(Operator):
 
 
 classes = (
-    QAS_OT_delete_selected_assets,
+    QAM_OT_delete_selected_assets,
 )

--- a/QuickAssetSaver/operators/file_io.py
+++ b/QuickAssetSaver/operators/file_io.py
@@ -9,6 +9,7 @@ from pathlib import Path
 import bpy
 
 from .utils import debug_print, MIN_BLEND_FILE_SIZE, ASSET_DATABLOCK_COLLECTIONS
+from ..compatibility import get_sequencer_strips
 
 
 def collect_external_dependencies(datablock):
@@ -127,7 +128,7 @@ def collect_external_dependencies(datablock):
             if datablock.world.use_nodes and datablock.world.node_tree:
                 collect_from_node_tree(datablock.world.node_tree)
         if hasattr(datablock, 'sequence_editor') and datablock.sequence_editor:
-            for seq in datablock.sequence_editor.sequences_all:
+            for seq in get_sequencer_strips(datablock.sequence_editor):
                 if hasattr(seq, 'sound') and seq.sound:
                     dependencies['sounds'].add(seq.sound)
                 if hasattr(seq, 'clip') and seq.clip:
@@ -158,6 +159,59 @@ def collect_external_dependencies(datablock):
         dependencies['volumes'].add(datablock)
 
     return dependencies
+
+
+def _strip_scene_references(node_tree, _seen=None):
+    """
+    Temporarily clear direct Scene references inside a node tree so writing
+    it doesn't pull the entire scene (and everything it contains) into the
+    asset file.
+
+    Compositor node groups commonly contain a Render Layer node with a
+    'scene' pointer property. bpy.data.libraries.write() follows ID
+    pointers recursively, so leaving that pointer set causes the referenced
+    Scene - and all objects/collections it contains - to be written
+    alongside the asset. Geometry/Shader node groups don't normally hold
+    such references, so this only has an effect on compositor trees.
+
+    Recurses into nested node groups (e.g. compositor group nodes) so
+    references buried a few levels deep are also caught.
+
+    Args:
+        node_tree: bpy.types.NodeTree to scan
+        _seen: internal set of already-visited node tree names (recursion guard)
+
+    Returns:
+        list of (node, attr_name, original_value) tuples to restore afterward
+    """
+    if _seen is None:
+        _seen = set()
+    if node_tree is None or node_tree.name in _seen:
+        return []
+    _seen.add(node_tree.name)
+
+    cleared = []
+    for node in node_tree.nodes:
+        scene = getattr(node, "scene", None)
+        if isinstance(scene, bpy.types.Scene):
+            cleared.append((node, "scene", scene))
+            node.scene = None
+            debug_print(f"Cleared scene reference on node '{node.name}' to avoid pulling entire scene into asset file")
+
+        nested_tree = getattr(node, "node_tree", None)
+        if nested_tree is not None:
+            cleared.extend(_strip_scene_references(nested_tree, _seen))
+
+    return cleared
+
+
+def _restore_scene_references(cleared_refs):
+    """Restore Scene pointers previously cleared by _strip_scene_references."""
+    for node, attr, value in cleared_refs:
+        try:
+            setattr(node, attr, value)
+        except (RuntimeError, ReferenceError, AttributeError):
+            pass
 
 
 def collect_selected_assets_with_names(context):
@@ -356,11 +410,16 @@ def write_blend_file(filepath, datablocks):
         'movieclips': [],
         'volumes': [],
     }
+    cleared_scene_refs = []
 
     try:
         filepath = Path(filepath)
         temp_dir = filepath.parent
         temp_file = temp_dir / f".tmp_{filepath.name}"
+
+        for datablock in datablocks:
+            if isinstance(datablock, bpy.types.NodeTree):
+                cleared_scene_refs.extend(_strip_scene_references(datablock))
 
         all_dependencies = {
             'images': set(),
@@ -425,6 +484,9 @@ def write_blend_file(filepath, datablocks):
             compress=True,
         )
 
+        _restore_scene_references(cleared_scene_refs)
+        cleared_scene_refs = []
+
         for image in packed_items['images']:
             try:
                 if image.packed_file:
@@ -461,6 +523,7 @@ def write_blend_file(filepath, datablocks):
 
     except (OSError, IOError) as e:
         print(f"Error writing blend file: {e}")
+        _restore_scene_references(cleared_scene_refs)
         _restore_packed_items(packed_items)
         if temp_file and temp_file.exists():
             try:

--- a/QuickAssetSaver/operators/manage.py
+++ b/QuickAssetSaver/operators/manage.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Asset management operators for Quick Asset Saver.
 
 This module re-exports operators from their individual modules for
@@ -7,17 +7,17 @@ backwards compatibility. The actual implementations are in:
 - delete.py: Delete operator
 """
 
-from .move import QAS_OT_move_selected_to_library
-from .delete import QAS_OT_delete_selected_assets
+from .move import QAM_OT_move_selected_to_library
+from .delete import QAM_OT_delete_selected_assets
 
 # Re-export classes tuple for registration
 classes = (
-    QAS_OT_move_selected_to_library,
-    QAS_OT_delete_selected_assets,
+    QAM_OT_move_selected_to_library,
+    QAM_OT_delete_selected_assets,
 )
 
 __all__ = [
-    'QAS_OT_move_selected_to_library',
-    'QAS_OT_delete_selected_assets',
+    'QAM_OT_move_selected_to_library',
+    'QAM_OT_delete_selected_assets',
     'classes',
 ]

--- a/QuickAssetSaver/operators/metadata.py
+++ b/QuickAssetSaver/operators/metadata.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Metadata editing operator for Quick Asset Saver.
 """
 
@@ -12,10 +12,10 @@ from .utils import debug_print, refresh_asset_browser, ALL_DATABLOCK_COLLECTIONS
 from .move import THUMBNAIL_EXTENSIONS
 
 
-class QAS_OT_apply_metadata_changes(Operator):
+class QAM_OT_apply_metadata_changes(Operator):
     """Apply metadata changes to the asset in its source .blend file."""
 
-    bl_idname = "qas.apply_metadata_changes"
+    bl_idname = "qam.apply_metadata_changes"
     bl_label = "Apply Changes"
     bl_description = "Save metadata changes back to the asset's source file"
     bl_options = {"REGISTER"}
@@ -23,14 +23,14 @@ class QAS_OT_apply_metadata_changes(Operator):
     @classmethod
     def poll(cls, context):
         wm = context.window_manager
-        meta = getattr(wm, "qas_metadata_edit", None)
+        meta = getattr(wm, "qam_metadata_edit", None)
         if not meta:
             return False
         return meta.has_changes() and meta.source_file
 
     def execute(self, context):
         wm = context.window_manager
-        meta = wm.qas_metadata_edit
+        meta = wm.qam_metadata_edit
         
         source_path = Path(meta.source_file)
         if not source_path.exists():
@@ -111,7 +111,7 @@ class QAS_OT_apply_metadata_changes(Operator):
                     for name in names:
                         if name in collection:
                             existing_db = collection[name]
-                            temp_name = f"__QAS_META_TEMP_{name}_{id(existing_db)}"
+                            temp_name = f"__QAM_META_TEMP_{name}_{id(existing_db)}"
                             original_name = existing_db.name
                             existing_db.name = temp_name
                             renamed_existing.append((existing_db, original_name))
@@ -335,9 +335,9 @@ class QAS_OT_apply_metadata_changes(Operator):
             pass
 
 
-class QAS_OT_toggle_edit_mode(Operator):
+class QAM_OT_toggle_edit_mode(Operator):
     """Toggle edit mode for asset metadata and tags"""
-    bl_idname = "qas.toggle_edit_mode"
+    bl_idname = "qam.toggle_edit_mode"
     bl_label = "Edit Metadata/Tags"
     bl_description = "Enable editing of metadata and tags (temporarily overrides native panels)"
     
@@ -366,6 +366,6 @@ class QAS_OT_toggle_edit_mode(Operator):
 
 
 classes = (
-    QAS_OT_apply_metadata_changes,
-    QAS_OT_toggle_edit_mode,
+    QAM_OT_apply_metadata_changes,
+    QAM_OT_toggle_edit_mode,
 )

--- a/QuickAssetSaver/operators/move.py
+++ b/QuickAssetSaver/operators/move.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Move operator for Quick Asset Saver.
 Handles moving assets between libraries with full companion file support.
 """
@@ -10,11 +10,19 @@ import bpy
 from bpy.types import Operator
 
 try:
-    from send2trash import send2trash
+    from send2trash import send2trash as _send2trash
+
+    def move_to_trash(path) -> None:
+        _send2trash(str(path))
+
 except ImportError:
-    def send2trash(path):
-        import os
-        os.remove(path)
+    def move_to_trash(path) -> None:
+        from pathlib import Path
+        p = Path(path)
+        raise RuntimeError(
+            f"Send2Trash is unavailable. '{p.name}' was NOT deleted.\n"
+            f"You can delete it manually at: {p.parent}"
+        )
 
 from .utils import (
     debug_print,
@@ -23,6 +31,12 @@ from .utils import (
     refresh_asset_browser,
     ALL_DATABLOCK_COLLECTIONS,
     ASSET_DATABLOCK_COLLECTIONS,
+)
+from ..constants import (
+    COMPANION_FOLDER_GROUPS,
+    COMPANION_FOLDER_NAMES,
+    THUMBNAIL_EXTENSIONS,
+    METADATA_EXTENSIONS,
 )
 from .catalog import get_catalog_path_from_uuid
 from .file_io import (
@@ -73,41 +87,10 @@ def _should_cleanup_empty_folder(folder_path):
         return False
 
 
-def get_addon_preferences():
-    """Get the addon preferences object."""
-    addon = bpy.context.preferences.addons.get(__package__.rsplit('.', 1)[0], None)
-    if addon:
-        return addon.preferences
-    return None
-
-
-# Common asset companion folder groups (case variations)
-COMPANION_FOLDER_GROUPS = [
-    ['textures', 'Textures', 'TEXTURES'],
-    ['maps', 'Maps', 'MAPS'],
-    ['materials', 'Materials', 'MATERIALS'],
-    ['shaders', 'Shaders', 'SHADERS'],
-    ['images', 'Images', 'IMAGES'],
-    ['hdri', 'HDRI', 'hdris', 'HDRIs'],
-    ['references', 'References', 'ref', 'Ref'],
-    ['documentation', 'Documentation', 'docs', 'Docs'],
-    ['resources', 'Resources', 'RESOURCES'],
-]
-
-# Flat list of all companion folder names for quick checking
-COMPANION_FOLDER_NAMES = [name for group in COMPANION_FOLDER_GROUPS for name in group]
-
-# Thumbnail file extensions
-THUMBNAIL_EXTENSIONS = ['.png', '.webp', '.jpg', '.jpeg']
-
-# Metadata file extensions
-METADATA_EXTENSIONS = ['.json', '.txt', '.md', '.xml']
-
-
-class QAS_OT_move_selected_to_library(Operator):
+class QAM_OT_move_selected_to_library(Operator):
     """Move selected assets to another library - handles multi-asset files correctly."""
 
-    bl_idname = "qas.move_selected_to_library"
+    bl_idname = "qam.move_selected_to_library"
     bl_label = "Move Assets"
     bl_description = "Move selected assets to the target library (extracts from multi-asset files)"
     bl_options = {"REGISTER"}
@@ -121,19 +104,28 @@ class QAS_OT_move_selected_to_library(Operator):
         )
 
     def execute(self, context):
-        from ..properties import get_library_by_identifier
+        from ..compatibility import is_protected_library
+        if is_protected_library(context):
+            self.report({"ERROR"}, "The Essentials library is protected and cannot be modified")
+            return {"CANCELLED"}
+        from ..properties import get_library_by_identifier, get_addon_preferences
 
-        prefs = get_addon_preferences()
+        prefs = get_addon_preferences(context)
         wm = context.window_manager
-        manage = getattr(wm, "qas_manage_props", None)
+        manage = getattr(wm, "qam_manage_props", None)
         if not manage:
             self.report({"ERROR"}, "Internal properties missing")
             return {"CANCELLED"}
 
-        selected_assets, active_library = collect_selected_assets_with_names(context)
-        if not selected_assets:
-            self.report({"WARNING"}, "No assets selected")
-            return {"CANCELLED"}
+        # Detect if we're operating from the Current File library
+        params = getattr(context.space_data, "params", None)
+        asset_lib_ref = None
+        if params:
+            asset_lib_ref = (
+                getattr(params, "asset_library_reference", None)
+                or getattr(params, "asset_library_ref", None)
+            )
+        is_current_file = asset_lib_ref in ("LOCAL", "CURRENT")
 
         if not manage.move_target_library or manage.move_target_library == "NONE":
             self.report({"ERROR"}, "Please choose a target library")
@@ -152,8 +144,17 @@ class QAS_OT_move_selected_to_library(Operator):
                 self.report({"ERROR"}, f"Cannot access target library: {e}")
                 return {"CANCELLED"}
 
+        # Current File: skip file-path collection and save each local datablock directly
+        if is_current_file:
+            return self._save_local_assets_to_library(context, manage, target_root, prefs)
+
+        # External library: resolve selected assets to .blend paths on disk
+        selected_assets, active_library = collect_selected_assets_with_names(context)
+        if not selected_assets:
+            self.report({"WARNING"}, "No assets selected")
+            return {"CANCELLED"}
+
         target_catalog_uuid = manage.move_target_catalog if manage.move_target_catalog else "UNASSIGNED"
-        
         debug_print(f"[Move Debug] Target catalog UUID: {target_catalog_uuid}")
         
         dest_base = target_root
@@ -268,6 +269,88 @@ class QAS_OT_move_selected_to_library(Operator):
         self.report({"INFO"}, ", ".join(msg_parts) if msg_parts else "No changes made")
         return {"FINISHED"}
 
+    def _save_local_assets_to_library(self, context, manage, target_root, prefs):
+        """Save Current File assets to a target library (bulk save, source unchanged).
+
+        For Current File assets, 'move' means 'copy to library'. The source
+        datablock stays in the current file — we cannot safely delete it
+        without modifying the user's unsaved work.
+        """
+        from .utils import sanitize_name, increment_filename, refresh_asset_browser
+        from .file_io import write_blend_file
+        from .catalog import get_catalog_path_from_uuid
+
+        target_catalog_uuid = manage.move_target_catalog if manage.move_target_catalog else "UNASSIGNED"
+
+        # Build destination base (respects catalog subfolders preference)
+        dest_base = target_root
+        if prefs and prefs.use_catalog_subfolders and target_catalog_uuid != "UNASSIGNED":
+            catalog_path = get_catalog_path_from_uuid(str(target_root), target_catalog_uuid)
+            if catalog_path:
+                for part in [p for p in catalog_path.split("/") if p]:
+                    dest_base = dest_base / sanitize_name(part, max_length=64)
+
+        try:
+            dest_base.mkdir(parents=True, exist_ok=True)
+        except Exception as e:
+            self.report({"ERROR"}, f"Could not create destination folders: {e}")
+            return {"CANCELLED"}
+
+        # Collect local datablocks
+        asset_files = None
+        if hasattr(context, "selected_asset_files") and context.selected_asset_files is not None:
+            asset_files = context.selected_asset_files
+        elif hasattr(context, "selected_assets") and context.selected_assets is not None:
+            asset_files = context.selected_assets
+
+        if not asset_files:
+            self.report({"WARNING"}, "No assets selected")
+            return {"CANCELLED"}
+
+        saved = 0
+        skipped = 0
+
+        for af in asset_files:
+            local_id = getattr(af, "local_id", None)
+            if local_id is None:
+                skipped += 1
+                continue
+
+            if not hasattr(local_id, "asset_data") or local_id.asset_data is None:
+                skipped += 1
+                continue
+
+            # Build destination path
+            filename = sanitize_name(local_id.name)
+            dest_path = dest_base / f"{filename}.blend"
+            if dest_path.exists():
+                dest_path = increment_filename(dest_base, filename, ".blend")
+
+            # Temporarily apply target catalog to the datablock, write, then restore
+            original_catalog_id = local_id.asset_data.catalog_id
+            try:
+                if target_catalog_uuid != "UNASSIGNED":
+                    local_id.asset_data.catalog_id = target_catalog_uuid
+
+                success = write_blend_file(dest_path, {local_id})
+            finally:
+                # Always restore the original catalog — do not modify the current file
+                local_id.asset_data.catalog_id = original_catalog_id
+
+            if success:
+                saved += 1
+            else:
+                skipped += 1
+
+        refresh_asset_browser(context)
+
+        if saved:
+            self.report({"INFO"}, f"Saved {saved} asset(s) to library" + (f" ({skipped} skipped)" if skipped else ""))
+        else:
+            self.report({"WARNING"}, "No assets were saved")
+
+        return {"FINISHED"}
+
     # -------------------------------------------------------------------------
     # Companion File Detection
     # -------------------------------------------------------------------------
@@ -380,7 +463,7 @@ class QAS_OT_move_selected_to_library(Operator):
                 # Check if source folder is now empty and clean it up
                 if _should_cleanup_empty_folder(source_parent):
                     try:
-                        send2trash(str(source_parent))
+                        move_to_trash(str(source_parent))
                         debug_print(f"Cleaned up empty source folder: {source_parent}")
                     except Exception as e:
                         debug_print(f"Could not cleanup empty folder {source_parent}: {e}")
@@ -540,7 +623,7 @@ class QAS_OT_move_selected_to_library(Operator):
         
         for item in items_to_trash:
             try:
-                send2trash(str(item))
+                move_to_trash(str(item))
                 debug_print(f"Sent to recycle bin: {item}")
             except Exception as e:
                 print(f"Warning: Could not trash {item}: {e}")
@@ -582,7 +665,7 @@ class QAS_OT_move_selected_to_library(Operator):
                 collection = getattr(bpy.data, target_collection)
                 if asset_name in collection:
                     existing_db = collection[asset_name]
-                    temp_name = f"__QAS_EXTRACT_TEMP_{asset_name}_{id(existing_db)}"
+                    temp_name = f"__QAM_EXTRACT_TEMP_{asset_name}_{id(existing_db)}"
                     original_name = existing_db.name
                     existing_db.name = temp_name
                     renamed_existing.append((existing_db, original_name))
@@ -652,7 +735,7 @@ class QAS_OT_move_selected_to_library(Operator):
                     for name in names:
                         if name in collection:
                             existing_db = collection[name]
-                            temp_name = f"__QAS_MOVE_TEMP_{name}_{id(existing_db)}"
+                            temp_name = f"__QAM_MOVE_TEMP_{name}_{id(existing_db)}"
                             original_name = existing_db.name
                             existing_db.name = temp_name
                             renamed_existing.append((existing_db, original_name))
@@ -738,7 +821,7 @@ class QAS_OT_move_selected_to_library(Operator):
                     for name in names:
                         if name in collection:
                             existing_db = collection[name]
-                            temp_name = f"__QAS_CAT_TEMP_{name}_{id(existing_db)}"
+                            temp_name = f"__QAM_CAT_TEMP_{name}_{id(existing_db)}"
                             original_name = existing_db.name
                             existing_db.name = temp_name
                             renamed_existing.append((existing_db, original_name))
@@ -843,5 +926,5 @@ class QAS_OT_move_selected_to_library(Operator):
 
 
 classes = (
-    QAS_OT_move_selected_to_library,
+    QAM_OT_move_selected_to_library,
 )

--- a/QuickAssetSaver/operators/move.py
+++ b/QuickAssetSaver/operators/move.py
@@ -4,6 +4,7 @@ Handles moving assets between libraries with full companion file support.
 """
 
 import shutil
+import time
 from pathlib import Path
 
 import bpy
@@ -84,6 +85,22 @@ def _should_cleanup_empty_folder(folder_path):
         
     except Exception:
         return False
+
+
+def _resolve_move_conflict(dest, conflict_resolution):
+    """Resolve a destination path against an existing-file conflict.
+
+    Returns (final_dest, skip). If skip is True, the caller should skip
+    this item entirely (user chose to skip files that already exist).
+    """
+    if not dest.exists():
+        return dest, False
+    if conflict_resolution == "OVERWRITE":
+        return dest, False
+    if conflict_resolution == "CANCEL":  # "Skip" in the UI
+        return dest, True
+    # INCREMENT (default)
+    return increment_filename(dest.parent, dest.stem, dest.suffix), False
 
 
 class QAM_OT_move_selected_to_library(Operator):
@@ -221,8 +238,10 @@ class QAM_OT_move_selected_to_library(Operator):
                             debug_print("[Move Debug] Failed to update catalog")
                         continue
                     
-                    if dest.exists():
-                        dest = increment_filename(dest.parent, dest.stem, dest.suffix)
+                    dest, skip = _resolve_move_conflict(dest, manage.move_conflict_resolution)
+                    if skip:
+                        skipped += 1
+                        continue
                     
                     success = self._move_file_with_companions(
                         src_path, dest, selected_names, catalog_to_set
@@ -238,8 +257,10 @@ class QAM_OT_move_selected_to_library(Operator):
                             dest_filename = f"{sanitize_name(asset_name)}.blend"
                             dest = dest_base / dest_filename
                             
-                            if dest.exists():
-                                dest = increment_filename(dest.parent, sanitize_name(asset_name), ".blend")
+                            dest, skip = _resolve_move_conflict(dest, manage.move_conflict_resolution)
+                            if skip:
+                                skipped += 1
+                                continue
                             
                             success = self._extract_asset_to_file(
                                 src_path, asset_name, dest, catalog_to_set
@@ -269,6 +290,9 @@ class QAM_OT_move_selected_to_library(Operator):
             msg_parts.append(f"skipped {skipped}")
         
         self.report({"INFO"}, ", ".join(msg_parts) if msg_parts else "No changes made")
+        if moved or extracted:
+            manage.show_success_message = True
+            manage.success_message_time = time.time()
         return {"FINISHED"}
 
     def _save_local_assets_to_library(self, context, manage, target_root, prefs):
@@ -278,7 +302,7 @@ class QAM_OT_move_selected_to_library(Operator):
         datablock stays in the current file — we cannot safely delete it
         without modifying the user's unsaved work.
         """
-        from .utils import sanitize_name, increment_filename, refresh_asset_browser
+        from .utils import sanitize_name, refresh_asset_browser
         from .file_io import write_blend_file
         from .catalog import get_catalog_path_from_uuid
 
@@ -325,8 +349,10 @@ class QAM_OT_move_selected_to_library(Operator):
             # Build destination path
             filename = sanitize_name(local_id.name)
             dest_path = dest_base / f"{filename}.blend"
-            if dest_path.exists():
-                dest_path = increment_filename(dest_base, filename, ".blend")
+            dest_path, skip = _resolve_move_conflict(dest_path, manage.move_conflict_resolution)
+            if skip:
+                skipped += 1
+                continue
 
             # Temporarily apply target catalog to the datablock, write, then restore
             original_catalog_id = local_id.asset_data.catalog_id
@@ -348,6 +374,8 @@ class QAM_OT_move_selected_to_library(Operator):
 
         if saved:
             self.report({"INFO"}, f"Saved {saved} asset(s) to library" + (f" ({skipped} skipped)" if skipped else ""))
+            manage.show_success_message = True
+            manage.success_message_time = time.time()
         else:
             self.report({"WARNING"}, "No assets were saved")
 

--- a/QuickAssetSaver/operators/move.py
+++ b/QuickAssetSaver/operators/move.py
@@ -34,7 +34,6 @@ from .utils import (
 )
 from ..constants import (
     COMPANION_FOLDER_GROUPS,
-    COMPANION_FOLDER_NAMES,
     THUMBNAIL_EXTENSIONS,
     METADATA_EXTENSIONS,
 )

--- a/QuickAssetSaver/operators/move.py
+++ b/QuickAssetSaver/operators/move.py
@@ -103,9 +103,12 @@ class QAM_OT_move_selected_to_library(Operator):
         )
 
     def execute(self, context):
-        from ..compatibility import is_protected_library
+        from ..compatibility import is_protected_library, is_online_library
         if is_protected_library(context):
             self.report({"ERROR"}, "The Essentials library is protected and cannot be modified")
+            return {"CANCELLED"}
+        if is_online_library(context):
+            self.report({"ERROR"}, "Online libraries cannot be modified")
             return {"CANCELLED"}
         from ..properties import get_library_by_identifier, get_addon_preferences
 

--- a/QuickAssetSaver/operators/save.py
+++ b/QuickAssetSaver/operators/save.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Save asset operator for Quick Asset Saver.
 """
 
@@ -19,18 +19,49 @@ from .catalog import get_catalog_path_from_uuid
 from .file_io import write_blend_file
 
 
-def get_addon_preferences():
-    """Get the addon preferences object."""
-    addon = bpy.context.preferences.addons.get(__package__.rsplit('.', 1)[0], None)
-    if addon:
-        return addon.preferences
-    return None
+def _auto_create_catalog_if_needed(library_path_str: str, source_catalog_uuid: str):
+    """
+    Resolve source_catalog_uuid (the asset's existing catalog from the Current File)
+    to a catalog path string, then ensure that path exists in the target library —
+    creating it if not. Returns the UUID to use when saving to the target library,
+    or None if the path could not be resolved.
+
+    Resolution order for the path:
+    1. Current file's sibling blender_assets.cats.txt (if file is saved)
+    2. The target library's own CDF (already migrated in a prior save)
+
+    Never raises — failures must not block the save.
+    """
+    from .catalog import get_catalog_path_from_uuid, create_catalog_entry
+
+    catalog_path = None
+
+    # Try to resolve from the current file's CDF first
+    if bpy.data.filepath:
+        current_dir = str(Path(bpy.data.filepath).parent)
+        catalog_path = get_catalog_path_from_uuid(current_dir, source_catalog_uuid)
+
+    # Fallback: UUID already exists in target library from a prior save
+    if not catalog_path:
+        catalog_path = get_catalog_path_from_uuid(library_path_str, source_catalog_uuid)
+
+    if not catalog_path:
+        if bpy.app.debug:
+            print(f"[QAM] auto_create_catalog: could not resolve UUID {source_catalog_uuid} to a path — skipping")
+        return None
+
+    try:
+        return create_catalog_entry(library_path_str, catalog_path)
+    except Exception as e:
+        if bpy.app.debug:
+            print(f"[QAM] auto_create_catalog: failed to create entry: {e}")
+        return None
 
 
-class QAS_OT_save_asset_to_library_direct(Operator):
+class QAM_OT_save_asset_to_library_direct(Operator):
     """Save selected asset directly from panel without popup"""
 
-    bl_idname = "qas.save_asset_to_library_direct"
+    bl_idname = "qam.save_asset_to_library_direct"
     bl_label = "Copy to Asset Library"
     bl_description = "Save this asset as a standalone .blend file in your asset library"
     bl_options = {"REGISTER", "UNDO"}
@@ -41,7 +72,6 @@ class QAS_OT_save_asset_to_library_direct(Operator):
         items=[
             ("INCREMENT", "Save with New Name", "Save as Name_001.blend, etc."),
             ("OVERWRITE", "Overwrite", "Replace the existing file"),
-            ("CANCEL", "Cancel", "Don't save"),
         ],
         default="INCREMENT",
     )
@@ -55,7 +85,7 @@ class QAS_OT_save_asset_to_library_direct(Operator):
         
         prefs = properties.get_addon_preferences(context)
         wm = context.window_manager
-        props = wm.qas_save_props
+        props = wm.qam_save_props
         
         # Ensure asset name is synced to our properties
         asset = getattr(context, "asset", None)
@@ -103,8 +133,8 @@ class QAS_OT_save_asset_to_library_direct(Operator):
         
         base_name = props.asset_file_name
         if not base_name:
-            debug_print(f"[QAS Debug] asset_display_name: '{props.asset_display_name}'")
-            debug_print(f"[QAS Debug] asset_file_name: '{props.asset_file_name}'")
+            debug_print(f"[QAM Debug] asset_display_name: '{props.asset_display_name}'")
+            debug_print(f"[QAM Debug] asset_file_name: '{props.asset_file_name}'")
             self.report({"ERROR"}, "Invalid file name")
             return {"CANCELLED"}
         
@@ -137,7 +167,7 @@ class QAS_OT_save_asset_to_library_direct(Operator):
 
         prefs = properties.get_addon_preferences(context)
         wm = context.window_manager
-        props = wm.qas_save_props
+        props = wm.qam_save_props
 
         if not props.selected_library or props.selected_library == "NONE":
             self.report({"ERROR"}, "No asset library selected")
@@ -145,9 +175,9 @@ class QAS_OT_save_asset_to_library_direct(Operator):
 
         library_name, library_path_str = get_library_by_identifier(props.selected_library)
         
-        debug_print(f"[QAS Debug] Selected library identifier: {props.selected_library}")
-        debug_print(f"[QAS Debug] Resolved library name: {library_name}")
-        debug_print(f"[QAS Debug] Resolved library path: {library_path_str}")
+        debug_print(f"[QAM Debug] Selected library identifier: {props.selected_library}")
+        debug_print(f"[QAM Debug] Resolved library name: {library_name}")
+        debug_print(f"[QAM Debug] Resolved library path: {library_path_str}")
         
         if not library_path_str:
             self.report({"ERROR"}, f"Could not find library for: {props.selected_library}. Please re-select the library.")
@@ -160,13 +190,28 @@ class QAS_OT_save_asset_to_library_direct(Operator):
 
         target_dir = library_path
 
+        # Determine the catalog UUID to assign to the saved asset.
+        # When auto-create is on: read the asset's existing catalog from the Current File
+        # and ensure it exists in the target library, creating it if needed.
+        # This lets the asset land in the right catalog even if the target library
+        # doesn't have that catalog yet — bypassing the dropdown entirely.
+        effective_catalog_uuid = props.catalog if props.catalog != "UNASSIGNED" else None
+
+        if props.auto_create_catalog:
+            asset_local = getattr(getattr(context, "asset", None), "local_id", None)
+            if asset_local and asset_local.asset_data:
+                source_catalog_id = asset_local.asset_data.catalog_id
+                if source_catalog_id:
+                    created_uuid = _auto_create_catalog_if_needed(library_path_str, source_catalog_id)
+                    if created_uuid:
+                        effective_catalog_uuid = created_uuid
+
         if (
             prefs.use_catalog_subfolders
-            and props.catalog
-            and props.catalog != "UNASSIGNED"
+            and effective_catalog_uuid
         ):
             catalog_path = get_catalog_path_from_uuid(
-                library_path_str, props.catalog
+                library_path_str, effective_catalog_uuid
             )
 
             if catalog_path:
@@ -226,6 +271,11 @@ class QAS_OT_save_asset_to_library_direct(Operator):
         if not asset_id.asset_data:
             asset_id.asset_mark()
 
+        # Capture originals before modifying in-memory — must restore after write
+        # so the source asset in the current file is not permanently affected.
+        _original_name = asset_id.name if asset_id else None
+        _original_catalog_id = asset_id.asset_data.catalog_id if asset_id and asset_id.asset_data else None
+
         if asset_id.asset_data:
             asset_id.name = props.asset_display_name
 
@@ -234,12 +284,18 @@ class QAS_OT_save_asset_to_library_direct(Operator):
             asset_id.asset_data.license = props.asset_license
             asset_id.asset_data.copyright = props.asset_copyright
 
-            if props.catalog and props.catalog != "UNASSIGNED":
-                asset_id.asset_data.catalog_id = props.catalog
+            if effective_catalog_uuid:
+                asset_id.asset_data.catalog_id = effective_catalog_uuid
 
         datablocks = {asset_id}
 
         success = write_blend_file(output_path, datablocks)
+
+        # Restore in-memory state so the source asset is unchanged in the current file
+        if _original_name is not None and asset_id:
+            asset_id.name = _original_name
+        if _original_catalog_id is not None and asset_id and asset_id.asset_data:
+            asset_id.asset_data.catalog_id = _original_catalog_id
 
         if not success:
             self.report({"ERROR"}, f"Failed to write {output_path.name}")
@@ -256,10 +312,10 @@ class QAS_OT_save_asset_to_library_direct(Operator):
         return {"FINISHED"}
 
 
-class QAS_OT_open_library_folder(Operator):
+class QAM_OT_open_library_folder(Operator):
     """Open the asset library folder in the system file browser"""
 
-    bl_idname = "qas.open_library_folder"
+    bl_idname = "qam.open_library_folder"
     bl_label = "Open Library Folder"
     bl_description = "Open the configured asset library folder in your file browser"
     bl_options = {"REGISTER"}
@@ -269,7 +325,7 @@ class QAS_OT_open_library_folder(Operator):
         from ..properties import get_library_by_identifier
 
         wm = context.window_manager
-        props = wm.qas_save_props
+        props = wm.qam_save_props
 
         if not props.selected_library or props.selected_library == "NONE":
             self.report({"ERROR"}, "No asset library selected")
@@ -290,6 +346,6 @@ class QAS_OT_open_library_folder(Operator):
 
 
 classes = (
-    QAS_OT_save_asset_to_library_direct,
-    QAS_OT_open_library_folder,
+    QAM_OT_save_asset_to_library_direct,
+    QAM_OT_open_library_folder,
 )

--- a/QuickAssetSaver/operators/swap.py
+++ b/QuickAssetSaver/operators/swap.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Swap/replace operator for Quick Asset Saver.
 """
 
@@ -9,10 +9,10 @@ from bpy.types import Operator
 from .file_io import collect_selected_asset_files
 
 
-class QAS_OT_swap_selected_with_asset(Operator):
+class QAM_OT_swap_selected_with_asset(Operator):
     """Swap selected scene objects with the selected asset from the library."""
 
-    bl_idname = "qas.swap_selected_with_asset"
+    bl_idname = "qam.swap_selected_with_asset"
     bl_label = "Replace with Asset"
     bl_description = "Replace selected objects in the scene with the selected asset (respects Asset Browser import settings)"
     bl_options = {"REGISTER", "UNDO"}
@@ -211,5 +211,5 @@ class QAS_OT_swap_selected_with_asset(Operator):
 
 
 classes = (
-    QAS_OT_swap_selected_with_asset,
+    QAM_OT_swap_selected_with_asset,
 )

--- a/QuickAssetSaver/operators/swap.py
+++ b/QuickAssetSaver/operators/swap.py
@@ -58,8 +58,10 @@ class QAM_OT_swap_selected_with_asset(Operator):
         instance_collections = False
         
         import_method = getattr(space.params, 'import_method', 'FOLLOW_PREFS')
-        
-        if import_method == 'FOLLOW_PREFS':
+
+        # 'FOLLOW_PREFS' was renamed to 'FOLLOW_ASSET' in Blender 5.2 (commit e428159ecc).
+        # Handle both values so the operator works across versions.
+        if import_method in ('FOLLOW_PREFS', 'FOLLOW_ASSET'):
             prefs = context.preferences.filepaths
             import_method = getattr(prefs, 'asset_import_method', 'APPEND')
         

--- a/QuickAssetSaver/operators/utils.py
+++ b/QuickAssetSaver/operators/utils.py
@@ -7,8 +7,6 @@ from pathlib import Path
 
 import bpy
 
-DEBUG_MODE = False
-
 from ..constants import (
     MIN_BLEND_FILE_SIZE,
     MAX_INCREMENTAL_FILES,
@@ -17,6 +15,7 @@ from ..constants import (
     DEFAULT_MAX_BUNDLE_SIZE_MB,
 )
 
+DEBUG_MODE = bpy.app.debug
 # Complete list of all Blender datablock collection names that can contain user data.
 # Used when loading/writing .blend files to preserve ALL data in the file.
 # Note: Not all of these exist in all Blender versions.

--- a/QuickAssetSaver/operators/utils.py
+++ b/QuickAssetSaver/operators/utils.py
@@ -8,14 +8,15 @@ from pathlib import Path
 import bpy
 
 from ..constants import (
-    MIN_BLEND_FILE_SIZE,
+    MIN_BLEND_FILE_SIZE,  # noqa: F401 (re-exported for file_io.py, bundle.py)
     MAX_INCREMENTAL_FILES,
-    LARGE_SELECTION_WARNING_THRESHOLD,
-    VERY_LARGE_BUNDLE_WARNING_MB,
-    DEFAULT_MAX_BUNDLE_SIZE_MB,
+    LARGE_SELECTION_WARNING_THRESHOLD,  # noqa: F401 (re-exported for bundle.py)
+    VERY_LARGE_BUNDLE_WARNING_MB,  # noqa: F401 (re-exported for bundle.py)
+    DEFAULT_MAX_BUNDLE_SIZE_MB,  # noqa: F401 (re-exported for bundle.py)
 )
 
 DEBUG_MODE = bpy.app.debug
+
 # Complete list of all Blender datablock collection names that can contain user data.
 # Used when loading/writing .blend files to preserve ALL data in the file.
 # Note: Not all of these exist in all Blender versions.

--- a/QuickAssetSaver/operators/utils.py
+++ b/QuickAssetSaver/operators/utils.py
@@ -9,12 +9,13 @@ import bpy
 
 DEBUG_MODE = False
 
-MIN_BLEND_FILE_SIZE = 100
-MAX_INCREMENTAL_FILES = 9999
-
-LARGE_SELECTION_WARNING_THRESHOLD = 25
-VERY_LARGE_BUNDLE_WARNING_MB = 5000
-DEFAULT_MAX_BUNDLE_SIZE_MB = 4096
+from ..constants import (
+    MIN_BLEND_FILE_SIZE,
+    MAX_INCREMENTAL_FILES,
+    LARGE_SELECTION_WARNING_THRESHOLD,
+    VERY_LARGE_BUNDLE_WARNING_MB,
+    DEFAULT_MAX_BUNDLE_SIZE_MB,
+)
 
 # Complete list of all Blender datablock collection names that can contain user data.
 # Used when loading/writing .blend files to preserve ALL data in the file.
@@ -111,7 +112,7 @@ def refresh_asset_browser_deferred():
                         area.tag_redraw()
     except Exception as e:
         if DEBUG_MODE:
-            print(f"[QAS] Deferred refresh failed: {e}")
+            print(f"[QAM] Deferred refresh failed: {e}")
     return None
 
 

--- a/QuickAssetSaver/panels.py
+++ b/QuickAssetSaver/panels.py
@@ -1,4 +1,4 @@
-
+﻿
 import bpy
 
 from .properties import DEBUG_MODE
@@ -97,10 +97,10 @@ def _find_tool_props_keybinding():
     return "N"
 
 
-class QAS_PT_save_hint(bpy.types.Panel):
+class QAM_PT_save_hint(bpy.types.Panel):
     """Hint panel shown in Current File to direct users to the right-side Save panel."""
     bl_label = "Quick Asset Saver"
-    bl_idname = "QAS_PT_save_hint"
+    bl_idname = "QAM_PT_save_hint"
     bl_space_type = "FILE_BROWSER"
     bl_region_type = "TOOLS"
     bl_category = "Assets"
@@ -131,29 +131,29 @@ class QAS_PT_save_hint(bpy.types.Panel):
         key_str = _find_tool_props_keybinding()
         box.label(text=f"Open it with your ( {key_str} ) key.", icon="BLANK1")
 
-class QAS_UL_metadata_tags(bpy.types.UIList):
+class QAM_UL_metadata_tags(bpy.types.UIList):
     """UIList for displaying and editing asset tags."""
-    bl_idname = "QAS_UL_metadata_tags"
+    bl_idname = "QAM_UL_metadata_tags"
     
     def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
         # Draw the tag name as an editable property
         layout.prop(item, "name", text="", emboss=False, icon='NONE')
 
 
-class QAS_OT_tag_add(bpy.types.Operator):
+class QAM_OT_tag_add(bpy.types.Operator):
     """Add a new tag to the asset"""
-    bl_idname = "qas.tag_add"
+    bl_idname = "qam.tag_add"
     bl_label = "Add Tag"
     bl_options = {'REGISTER', 'UNDO'}
     
     @classmethod
     def poll(cls, context):
         wm = context.window_manager
-        return hasattr(wm, "qas_metadata_edit")
+        return hasattr(wm, "qam_metadata_edit")
     
     def execute(self, context):
         wm = context.window_manager
-        meta = wm.qas_metadata_edit
+        meta = wm.qam_metadata_edit
         
         tag = meta.edit_tags.add()
         tag.name = "Tag"
@@ -162,23 +162,23 @@ class QAS_OT_tag_add(bpy.types.Operator):
         return {'FINISHED'}
 
 
-class QAS_OT_tag_remove(bpy.types.Operator):
+class QAM_OT_tag_remove(bpy.types.Operator):
     """Remove the selected tag"""
-    bl_idname = "qas.tag_remove"
+    bl_idname = "qam.tag_remove"
     bl_label = "Remove Tag"
     bl_options = {'REGISTER', 'UNDO'}
     
     @classmethod
     def poll(cls, context):
         wm = context.window_manager
-        if not hasattr(wm, "qas_metadata_edit"):
+        if not hasattr(wm, "qam_metadata_edit"):
             return False
-        meta = wm.qas_metadata_edit
+        meta = wm.qam_metadata_edit
         return len(meta.edit_tags) > 0 and meta.active_tag_index >= 0
     
     def execute(self, context):
         wm = context.window_manager
-        meta = wm.qas_metadata_edit
+        meta = wm.qam_metadata_edit
         
         if meta.active_tag_index < len(meta.edit_tags):
             meta.edit_tags.remove(meta.active_tag_index)
@@ -189,14 +189,14 @@ class QAS_OT_tag_remove(bpy.types.Operator):
         return {'FINISHED'}
 
 
-class QAS_MT_asset_context_menu(bpy.types.Menu):
+class QAM_MT_asset_context_menu(bpy.types.Menu):
     """Quick Asset Saver context menu items for the Asset Browser."""
-    bl_idname = "QAS_MT_asset_context_menu"
+    bl_idname = "QAM_MT_asset_context_menu"
     bl_label = "Quick Asset Saver"
 
     def draw(self, context):
         layout = self.layout
-        layout.operator("qas.delete_selected_assets", text="Remove Asset from Library", icon="TRASH")
+        layout.operator("qam.delete_selected_assets", text="Remove Asset from Library", icon="TRASH")
 
 
 def draw_asset_context_menu(self, context):
@@ -216,15 +216,15 @@ def draw_asset_context_menu(self, context):
     if not is_current_file:
         layout = self.layout
         layout.separator()
-        layout.operator("qas.swap_selected_with_asset", text="Replace Selected Objects", icon="FILE_REFRESH")
-        layout.operator("qas.delete_selected_assets", text="Remove Asset from Library", icon="TRASH")
+        layout.operator("qam.swap_selected_with_asset", text="Replace Selected Objects", icon="FILE_REFRESH")
+        layout.operator("qam.delete_selected_assets", text="Remove Asset from Library", icon="TRASH")
 
 
 # ============================================================================
 # BULK OPERATIONS PANEL (RIGHT SIDE - for 2+ assets)
 # ============================================================================
 
-class QAS_PT_bulk_operations(bpy.types.Panel):
+class QAM_PT_bulk_operations(bpy.types.Panel):
     """Panel for bulk operations when 2+ assets are selected."""
     
     bl_space_type = 'FILE_BROWSER'
@@ -256,8 +256,8 @@ class QAS_PT_bulk_operations(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         wm = context.window_manager
-        bundler_props = wm.qas_bundler_props
-        manage_props = getattr(wm, "qas_manage_props", None)
+        bundler_props = wm.qam_bundler_props
+        manage_props = getattr(wm, "qam_manage_props", None)
         
         selected_count = _count_selected_assets(context)
         
@@ -273,7 +273,7 @@ class QAS_PT_bulk_operations(bpy.types.Panel):
         
         row = box.row()
         row.scale_y = 1.2
-        row.operator("qas.move_selected_to_library", text=f"Move {selected_count} Assets", icon="EXPORT")
+        row.operator("qam.move_selected_to_library", text=f"Move {selected_count} Assets", icon="EXPORT")
         
         layout.separator()
         
@@ -287,7 +287,7 @@ class QAS_PT_bulk_operations(bpy.types.Panel):
         
         row = box.row()
         row.scale_y = 1.2
-        row.operator("qas.bundle_assets", text=f"Bundle {selected_count} Assets", icon="PACKAGE")
+        row.operator("qam.bundle_assets", text=f"Bundle {selected_count} Assets", icon="PACKAGE")
 
 
 def _get_asset_source_path(context):
@@ -348,7 +348,7 @@ def _get_asset_source_path(context):
     return None
 
 
-class QAS_PT_asset_actions(bpy.types.Panel):
+class QAM_PT_asset_actions(bpy.types.Panel):
     """Panel for asset actions - Apply Changes and Remove Asset for external assets."""
     
     bl_space_type = 'FILE_BROWSER'
@@ -384,8 +384,8 @@ class QAS_PT_asset_actions(bpy.types.Panel):
         layout = self.layout
         
         wm = context.window_manager
-        meta = getattr(wm, "qas_metadata_edit", None)
-        manage = getattr(wm, "qas_manage_props", None)
+        meta = getattr(wm, "qam_metadata_edit", None)
+        manage = getattr(wm, "qam_manage_props", None)
         
         # Check if asset changed (auto-exit edit mode)
         _check_and_exit_edit_mode(context)
@@ -395,17 +395,17 @@ class QAS_PT_asset_actions(bpy.types.Panel):
         row.scale_y = 1.3
         if _edit_mode_active:
             # In edit mode - show "Cancel" button
-            row.operator("qas.toggle_edit_mode", text="Cancel", icon="PANEL_CLOSE", depress=True)
+            row.operator("qam.toggle_edit_mode", text="Cancel", icon="PANEL_CLOSE", depress=True)
             
             # Show "Apply Changes" button below
             row = layout.row()
             row.scale_y = 1.3
             has_changes = meta.has_changes() if meta else False
             row.enabled = has_changes
-            row.operator("qas.apply_metadata_changes", text="Apply Changes", icon="CHECKMARK")
+            row.operator("qam.apply_metadata_changes", text="Apply Changes", icon="CHECKMARK")
         else:
             # Not in edit mode - show "Edit Metadata/Tags" button
-            row.operator("qas.toggle_edit_mode", text="Edit Metadata/Tags", icon="GREASEPENCIL")
+            row.operator("qam.toggle_edit_mode", text="Edit Metadata/Tags", icon="GREASEPENCIL")
         
         # Move section
         layout.separator()
@@ -417,16 +417,16 @@ class QAS_PT_asset_actions(bpy.types.Panel):
         
         move_row = box.row()
         move_row.scale_y = 1.2
-        move_row.operator("qas.move_selected_to_library", text="Move", icon="EXPORT")
+        move_row.operator("qam.move_selected_to_library", text="Move", icon="EXPORT")
         
         # Remove Asset button
         layout.separator()
         row = layout.row()
         row.scale_y = 1.2
-        row.operator("qas.delete_selected_assets", text="Remove Asset from Library", icon="TRASH")
+        row.operator("qam.delete_selected_assets", text="Remove Asset from Library", icon="TRASH")
 
 
-class QAS_PT_save_to_library(bpy.types.Panel):
+class QAM_PT_save_to_library(bpy.types.Panel):
     """Panel for saving local assets to a library - appears after Tags."""
     
     bl_space_type = 'FILE_BROWSER'
@@ -459,7 +459,7 @@ class QAS_PT_save_to_library(bpy.types.Panel):
     def draw(self, context):
         layout = self.layout
         wm = context.window_manager
-        props = getattr(wm, "qas_save_props", None)
+        props = getattr(wm, "qam_save_props", None)
         
         if not props:
             layout.label(text="Properties unavailable")
@@ -492,7 +492,7 @@ class QAS_PT_save_to_library(bpy.types.Panel):
         # Copy to Asset Library button
         row = layout.row()
         row.scale_y = 1.2
-        row.operator("qas.save_asset_to_library_direct", text="Copy to Asset Library", icon="EXPORT")
+        row.operator("qam.save_asset_to_library_direct", text="Copy to Asset Library", icon="EXPORT")
 
 
 # ============================================================================
@@ -514,7 +514,7 @@ def _draw_metadata_override(self, context):
     if is_local:
         # For local assets, draw our editable fields for saving
         wm = context.window_manager
-        props = getattr(wm, "qas_save_props", None)
+        props = getattr(wm, "qam_save_props", None)
         
         if not props:
             layout.label(text="Properties unavailable")
@@ -556,7 +556,7 @@ def _draw_metadata_override(self, context):
     else:
         # For external assets, draw our editable fields
         wm = context.window_manager
-        meta = getattr(wm, "qas_metadata_edit", None)
+        meta = getattr(wm, "qam_metadata_edit", None)
         
         if not meta:
             layout.label(text="Metadata editing unavailable")
@@ -625,7 +625,7 @@ def _draw_tags_override(self, context):
     else:
         # For external assets, show our custom editable tag list
         wm = context.window_manager
-        meta = getattr(wm, "qas_metadata_edit", None)
+        meta = getattr(wm, "qam_metadata_edit", None)
         
         if not meta:
             layout.label(text="Tags unavailable")
@@ -641,14 +641,14 @@ def _draw_tags_override(self, context):
         
         row = layout.row()
         row.template_list(
-            "QAS_UL_metadata_tags", "",
+            "QAM_UL_metadata_tags", "",
             meta, "edit_tags",
             meta, "active_tag_index",
             rows=3,
         )
         col = row.column(align=True)
-        col.operator("qas.tag_add", icon='ADD', text="")
-        col.operator("qas.tag_remove", icon='REMOVE', text="")
+        col.operator("qam.tag_add", icon='ADD', text="")
+        col.operator("qam.tag_remove", icon='REMOVE', text="")
         
         # Small gap before filtering options
         layout.separator(factor=0.3)
@@ -682,9 +682,9 @@ def _enter_edit_mode(context):
         if not _original_metadata_draw:
             _original_metadata_draw = ASSETBROWSER_PT_metadata.draw
         ASSETBROWSER_PT_metadata.draw = _draw_metadata_override
-        debug_print("[QAS] Entered edit mode - overrode metadata panel draw")
+        debug_print("[QAM] Entered edit mode - overrode metadata panel draw")
     except Exception as e:
-        debug_print(f"[QAS] Could not override metadata panel draw: {e}")
+        debug_print(f"[QAM] Could not override metadata panel draw: {e}")
     
     # Override native tags panel draw
     try:
@@ -692,9 +692,9 @@ def _enter_edit_mode(context):
         if not _original_tags_draw:
             _original_tags_draw = ASSETBROWSER_PT_metadata_tags.draw
         ASSETBROWSER_PT_metadata_tags.draw = _draw_tags_override
-        debug_print("[QAS] Entered edit mode - overrode tags panel draw")
+        debug_print("[QAM] Entered edit mode - overrode tags panel draw")
     except Exception as e:
-        debug_print(f"[QAS] Could not override tags panel draw: {e}")
+        debug_print(f"[QAM] Could not override tags panel draw: {e}")
     
     _edit_mode_active = True
     
@@ -716,9 +716,9 @@ def _exit_edit_mode():
         try:
             from bl_ui.space_filebrowser import ASSETBROWSER_PT_metadata
             ASSETBROWSER_PT_metadata.draw = _original_metadata_draw
-            debug_print("[QAS] Exited edit mode - restored metadata panel draw")
+            debug_print("[QAM] Exited edit mode - restored metadata panel draw")
         except Exception as e:
-            debug_print(f"[QAS] Could not restore metadata panel draw: {e}")
+            debug_print(f"[QAM] Could not restore metadata panel draw: {e}")
         _original_metadata_draw = None
     
     # Restore native tags panel draw
@@ -726,9 +726,9 @@ def _exit_edit_mode():
         try:
             from bl_ui.space_filebrowser import ASSETBROWSER_PT_metadata_tags
             ASSETBROWSER_PT_metadata_tags.draw = _original_tags_draw
-            debug_print("[QAS] Exited edit mode - restored tags panel draw")
+            debug_print("[QAM] Exited edit mode - restored tags panel draw")
         except Exception as e:
-            debug_print(f"[QAS] Could not restore tags panel draw: {e}")
+            debug_print(f"[QAM] Could not restore tags panel draw: {e}")
         _original_tags_draw = None
     
     _edit_mode_active = False
@@ -768,14 +768,14 @@ def _check_and_exit_edit_mode(context):
 
 
 classes = (
-    QAS_PT_save_hint,
-    QAS_PT_bulk_operations,
-    QAS_UL_metadata_tags,
-    QAS_OT_tag_add,
-    QAS_OT_tag_remove,
-    QAS_MT_asset_context_menu,
-    QAS_PT_asset_actions,
-    QAS_PT_save_to_library,
+    QAM_PT_save_hint,
+    QAM_PT_bulk_operations,
+    QAM_UL_metadata_tags,
+    QAM_OT_tag_add,
+    QAM_OT_tag_remove,
+    QAM_MT_asset_context_menu,
+    QAM_PT_asset_actions,
+    QAM_PT_save_to_library,
 )
 
 
@@ -784,7 +784,7 @@ def register():
         bpy.utils.register_class(cls)
     
     bpy.types.ASSETBROWSER_MT_context_menu.append(draw_asset_context_menu)
-    debug_print("[QAS] Registered Quick Asset Saver panels")
+    debug_print("[QAM] Registered Quick Asset Saver panels")
 
 
 def unregister():
@@ -796,4 +796,4 @@ def unregister():
     for cls in reversed(classes):
         bpy.utils.unregister_class(cls)
     
-    debug_print("[QAS] Unregistered Quick Asset Saver panels")
+    debug_print("[QAM] Unregistered Quick Asset Saver panels")

--- a/QuickAssetSaver/panels/__init__.py
+++ b/QuickAssetSaver/panels/__init__.py
@@ -1,0 +1,298 @@
+﻿"""
+Panels package for Quick Asset Manager.
+
+Manages the draw override for metadata edit mode. The native
+ASSETBROWSER_PT_metadata and ASSETBROWSER_PT_metadata_tags panels
+are temporarily replaced with editable versions when edit mode is active.
+
+NOTE: Any other addon that has appended to ASSETBROWSER_PT_metadata will
+have its appended content hidden during edit mode. This is a known,
+accepted tradeoff. The native panels are always fully restored on exit.
+"""
+
+import bpy
+
+from . import bulk_panel, context_menu, manage_panel, save_panel
+
+# ============================================================================
+# MODULE-LEVEL STATE
+# Module-level storage for draw refs and edit mode flags.
+# These hold function objects and primitive values — module-level is correct.
+# ============================================================================
+
+_original_metadata_draw = None
+_original_tags_draw = None
+_edit_mode_active = False
+_edit_mode_asset_key = ""
+
+
+# ============================================================================
+# HELPERS
+# ============================================================================
+
+def _get_asset_source_path(context):
+    """Get the source .blend file path for the active asset."""
+    from pathlib import Path
+
+    asset = getattr(context, "asset", None)
+    if not asset:
+        return None
+
+    def _extract(full_path_str):
+        if not full_path_str:
+            return None
+        idx = full_path_str.lower().find('.blend')
+        if idx != -1:
+            return Path(full_path_str[:idx + 6])
+        return None
+
+    if hasattr(asset, "full_path") and asset.full_path:
+        p = _extract(asset.full_path)
+        if p:
+            return p
+
+    if hasattr(asset, "full_library_path") and asset.full_library_path:
+        p = _extract(asset.full_library_path)
+        if p:
+            return p
+
+    return None
+
+
+def _check_and_exit_edit_mode(context) -> bool:
+    """Check if the selected asset changed; exit edit mode if so.
+    Called from manage_panel.draw() on every redraw."""
+    global _edit_mode_asset_key
+
+    if not _edit_mode_active:
+        return False
+
+    asset = getattr(context, "asset", None)
+    if not asset:
+        _exit_edit_mode()
+        return True
+
+    source_path = _get_asset_source_path(context)
+    current_key = f"{source_path}:{asset.name}" if source_path else asset.name
+
+    if current_key != _edit_mode_asset_key:
+        _exit_edit_mode()
+        return True
+
+    return False
+
+
+# ============================================================================
+# DRAW OVERRIDE FUNCTIONS
+# Defined here so both enter_edit_mode and _enter_edit_mode can reference them.
+# ============================================================================
+
+def _draw_metadata_override(self, context):
+    """Override for ASSETBROWSER_PT_metadata.draw() during edit mode."""
+    layout = self.layout
+
+    asset = getattr(context, "asset", None)
+    if not asset:
+        layout.label(text="No asset selected")
+        return
+
+    wm = context.window_manager
+    meta = getattr(wm, "qam_metadata_edit", None)
+
+    if not meta:
+        layout.label(text="Metadata editing unavailable")
+        return
+
+    source_path = _get_asset_source_path(context)
+    current_key = f"{source_path}:{asset.name}" if source_path else asset.name
+    stored_key = f"{meta.source_file}:{meta.asset_name}"
+
+    if current_key != stored_key:
+        meta.sync_from_asset(asset, source_path)
+
+    layout.separator(factor=0.5)
+    layout.prop(meta, "edit_name", text="Name")
+
+    col = layout.column(align=True)
+    col.enabled = False
+    col.label(text="Source")
+    if source_path:
+        path_str = str(source_path)
+        if len(path_str) > 40:
+            path_str = "..." + path_str[-37:]
+        col.label(text=path_str, icon='NONE')
+    else:
+        col.label(text="Unknown", icon='NONE')
+
+    layout.prop(meta, "edit_description", text="Description")
+    layout.prop(meta, "edit_license", text="License")
+    layout.prop(meta, "edit_copyright", text="Copyright")
+    layout.prop(meta, "edit_author", text="Author")
+
+
+def _draw_tags_override(self, context):
+    """Override for ASSETBROWSER_PT_metadata_tags.draw() during edit mode."""
+    layout = self.layout
+
+    asset = getattr(context, "asset", None)
+    if not asset:
+        return
+
+    wm = context.window_manager
+    meta = getattr(wm, "qam_metadata_edit", None)
+
+    if not meta:
+        layout.label(text="Tags unavailable")
+        return
+
+    source_path = _get_asset_source_path(context)
+    current_key = f"{source_path}:{asset.name}" if source_path else asset.name
+    stored_key = f"{meta.source_file}:{meta.asset_name}"
+
+    if current_key != stored_key:
+        meta.sync_from_asset(asset, source_path)
+
+    row = layout.row()
+    row.template_list(
+        "QAM_UL_metadata_tags", "",
+        meta, "edit_tags",
+        meta, "active_tag_index",
+        rows=3,
+    )
+    col = row.column(align=True)
+    col.operator("qam.tag_add", icon='ADD', text="")
+    col.operator("qam.tag_remove", icon='REMOVE', text="")
+
+    layout.separator(factor=0.3)
+
+
+# ============================================================================
+# EDIT MODE — CLEAN PUBLIC API
+# ============================================================================
+
+def enter_edit_mode(metadata_draw_fn, tags_draw_fn) -> bool:
+    """
+    Override Blender's native asset metadata panel draws with editable versions.
+    Called only by QAM_OT_toggle_edit_mode when toggling edit mode on.
+
+    Args:
+        metadata_draw_fn: Replacement draw function for ASSETBROWSER_PT_metadata
+        tags_draw_fn:     Replacement draw function for ASSETBROWSER_PT_metadata_tags
+
+    Returns:
+        True if override was applied successfully, False otherwise.
+
+    Sensitive to: ASSETBROWSER_PT_metadata and ASSETBROWSER_PT_metadata_tags
+    class names. If these change in a future Blender version this will fail
+    gracefully — native panels are left unaffected.
+    Check: bl_ui/space_filebrowser.py in the Blender source.
+    """
+    global _original_metadata_draw, _original_tags_draw
+    try:
+        from bl_ui.space_filebrowser import (
+            ASSETBROWSER_PT_metadata,
+            ASSETBROWSER_PT_metadata_tags,
+        )
+        _original_metadata_draw = ASSETBROWSER_PT_metadata.draw
+        _original_tags_draw = ASSETBROWSER_PT_metadata_tags.draw
+        ASSETBROWSER_PT_metadata.draw = metadata_draw_fn
+        ASSETBROWSER_PT_metadata_tags.draw = tags_draw_fn
+        if bpy.app.debug:
+            print("[QAM] Entered metadata edit mode — native panels overridden")
+        return True
+    except Exception as e:
+        if bpy.app.debug:
+            print(f"[QAM] Could not enter edit mode: {e}")
+        _original_metadata_draw = None
+        _original_tags_draw = None
+        return False
+
+
+def exit_edit_mode() -> None:
+    """
+    Restore Blender's native panel draws. Safe to call when not in edit mode.
+    Always called on unregister to ensure panels are never left overridden.
+    """
+    global _original_metadata_draw, _original_tags_draw
+    try:
+        from bl_ui.space_filebrowser import (
+            ASSETBROWSER_PT_metadata,
+            ASSETBROWSER_PT_metadata_tags,
+        )
+        if _original_metadata_draw is not None:
+            ASSETBROWSER_PT_metadata.draw = _original_metadata_draw
+        if _original_tags_draw is not None:
+            ASSETBROWSER_PT_metadata_tags.draw = _original_tags_draw
+        if bpy.app.debug:
+            print("[QAM] Exited metadata edit mode — native panels restored")
+    except Exception as e:
+        if bpy.app.debug:
+            print(f"[QAM] Error restoring native panels: {e}")
+    finally:
+        _original_metadata_draw = None
+        _original_tags_draw = None
+
+
+# ============================================================================
+# EDIT MODE — LEGACY WRAPPERS
+# Called by QAM_OT_toggle_edit_mode and QAM_OT_apply_metadata_changes in
+# operators/metadata.py. These wrap the clean API with state tracking.
+# ============================================================================
+
+def _enter_edit_mode(context) -> None:
+    """Enter edit mode using the embedded draw overrides. Used by toggle operator."""
+    global _edit_mode_active, _edit_mode_asset_key
+
+    if _edit_mode_active:
+        return
+
+    asset = getattr(context, "asset", None)
+    if asset:
+        source_path = _get_asset_source_path(context)
+        _edit_mode_asset_key = f"{source_path}:{asset.name}" if source_path else asset.name
+
+    success = enter_edit_mode(_draw_metadata_override, _draw_tags_override)
+    if success:
+        _edit_mode_active = True
+        try:
+            for area in context.screen.areas:
+                if area.type == 'FILE_BROWSER':
+                    area.tag_redraw()
+        except Exception:
+            pass
+
+
+def _exit_edit_mode() -> None:
+    """Exit edit mode and restore native panels. Used by toggle/apply/cancel."""
+    global _edit_mode_active, _edit_mode_asset_key
+
+    if not _edit_mode_active and _original_metadata_draw is None:
+        return
+
+    exit_edit_mode()
+    _edit_mode_active = False
+    _edit_mode_asset_key = ""
+
+    try:
+        for window in bpy.context.window_manager.windows:
+            for area in window.screen.areas:
+                if area.type == 'FILE_BROWSER':
+                    area.tag_redraw()
+    except Exception:
+        pass
+
+
+def register():
+    bulk_panel.register()
+    context_menu.register()
+    manage_panel.register()
+    save_panel.register()
+
+
+def unregister():
+    # Always exit edit mode on unregister — crash recovery and clean reload
+    exit_edit_mode()
+    save_panel.unregister()
+    manage_panel.unregister()
+    context_menu.unregister()
+    bulk_panel.unregister()

--- a/QuickAssetSaver/panels/bulk_panel.py
+++ b/QuickAssetSaver/panels/bulk_panel.py
@@ -57,6 +57,7 @@ class QAM_PT_bulk_operations(bpy.types.Panel):
         if manage_props is not None:
             move_box.prop(manage_props, "move_target_library", text="Library")
             move_box.prop(manage_props, "move_target_catalog", text="Catalog")
+            move_box.prop(manage_props, "move_conflict_resolution", text="If Exists")
 
         move_row = move_box.row()
         move_row.scale_y = 1.2
@@ -65,6 +66,13 @@ class QAM_PT_bulk_operations(bpy.types.Panel):
             text=f"Move {selected_count} Assets",
             icon="EXPORT",
         )
+
+        if manage_props is not None and manage_props.show_success_message:
+            if time.time() - manage_props.success_message_time < 4.0:
+                success_box = move_box.box()
+                success_box.label(text="Moved!", icon="CHECKMARK")
+            else:
+                manage_props.show_success_message = False
 
         layout.separator()
 

--- a/QuickAssetSaver/panels/bulk_panel.py
+++ b/QuickAssetSaver/panels/bulk_panel.py
@@ -1,0 +1,112 @@
+﻿import time
+
+import bpy
+
+from ..compatibility import is_asset_browser_active
+from ..constants import LARGE_SELECTION_WARNING_THRESHOLD
+
+
+def _count_selected_assets(context):
+    if hasattr(context, "selected_asset_files") and context.selected_asset_files is not None:
+        return len(context.selected_asset_files)
+    elif hasattr(context, "selected_assets") and context.selected_assets is not None:
+        return len(context.selected_assets)
+    elif hasattr(context.space_data, "files"):
+        try:
+            return len([f for f in context.space_data.files if getattr(f, "select", False)])
+        except (AttributeError, TypeError):
+            pass
+    return 0
+
+
+class QAM_PT_bulk_operations(bpy.types.Panel):
+    bl_idname = "QAM_PT_bulk_operations"
+    bl_space_type = 'FILE_BROWSER'
+    bl_region_type = 'TOOL_PROPS'
+    bl_label = "Bulk Operations"
+    bl_order = 1
+
+    @classmethod
+    def poll(cls, context):
+        if not is_asset_browser_active(context):
+            return False
+        return _count_selected_assets(context) >= 2
+
+    def draw(self, context):
+        layout = self.layout
+        wm = context.window_manager
+
+        selected_count = _count_selected_assets(context)
+
+        # Header
+        layout.label(text=f"{selected_count} Assets Selected", icon="ASSET_MANAGER")
+
+        # Large selection warning
+        if selected_count >= LARGE_SELECTION_WARNING_THRESHOLD:
+            box = layout.box()
+            box.label(text=f"Large selection ({selected_count} assets)", icon="ERROR")
+            box.label(text="This may take a while.")
+
+        layout.separator()
+
+        # Move box
+        move_box = layout.box()
+        move_box.label(text="Move Assets", icon="EXPORT")
+
+        manage_props = getattr(wm, "qam_manage_props", None)
+        if manage_props is not None:
+            move_box.prop(manage_props, "move_target_library", text="Library")
+            move_box.prop(manage_props, "move_target_catalog", text="Catalog")
+
+        move_row = move_box.row()
+        move_row.scale_y = 1.2
+        move_row.operator(
+            "qam.move_selected_to_library",
+            text=f"Move {selected_count} Assets",
+            icon="EXPORT",
+        )
+
+        layout.separator()
+
+        # Bundle box
+        bundle_box = layout.box()
+        bundle_box.label(text="Bundle Assets", icon="PACKAGE")
+
+        bundler_props = getattr(wm, "qam_bundler_props", None)
+        if bundler_props is not None:
+            bundle_box.prop(bundler_props, "output_name", text="Name")
+            bundle_box.prop(bundler_props, "save_path", text="Path")
+            # Blender deselects assets when the file picker opens — warn the user
+            hint = bundle_box.row()
+            hint.scale_y = 0.75
+            hint.label(text="Tip: selecting a path deselects assets", icon="INFO")
+            bundle_box.prop(bundler_props, "duplicate_mode", text="Duplicates")
+            bundle_box.prop(bundler_props, "copy_catalog")
+
+            if bundler_props.show_success_message:
+                if time.time() - bundler_props.success_message_time < 4.0:
+                    success_box = bundle_box.box()
+                    success_box.label(text="Bundle saved!", icon="CHECKMARK")
+                else:
+                    bundler_props.show_success_message = False
+
+        bundle_row = bundle_box.row()
+        bundle_row.scale_y = 1.2
+        bundle_row.operator(
+            "qam.bundle_assets",
+            text=f"Bundle {selected_count} Assets",
+            icon="PACKAGE",
+        )
+
+
+classes = (QAM_PT_bulk_operations,)
+
+
+def register():
+    for cls in classes:
+        bpy.utils.register_class(cls)
+
+
+def unregister():
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/QuickAssetSaver/panels/context_menu.py
+++ b/QuickAssetSaver/panels/context_menu.py
@@ -1,0 +1,34 @@
+﻿import bpy
+
+
+def draw_asset_context_menu(self, context):
+    if not hasattr(context, "space_data") or context.space_data.type != "FILE_BROWSER":
+        return
+    if getattr(context.space_data, "browse_mode", None) != "ASSETS":
+        return
+
+    params = getattr(context.space_data, "params", None)
+    if not params:
+        return
+
+    asset_lib_ref = getattr(params, "asset_library_reference", None)
+    if not asset_lib_ref:
+        asset_lib_ref = getattr(params, "asset_library_ref", None)
+
+    is_current_file = asset_lib_ref in ("LOCAL", "CURRENT") or asset_lib_ref is None
+
+    if is_current_file:
+        return
+
+    layout = self.layout
+    layout.separator()
+    layout.operator("qam.swap_selected_with_asset", text="Replace Selected Objects", icon="FILE_REFRESH")
+    layout.operator("qam.delete_selected_assets", text="Remove Asset from Library", icon="TRASH")
+
+
+def register():
+    bpy.types.ASSETBROWSER_MT_context_menu.append(draw_asset_context_menu)
+
+
+def unregister():
+    bpy.types.ASSETBROWSER_MT_context_menu.remove(draw_asset_context_menu)

--- a/QuickAssetSaver/panels/manage_panel.py
+++ b/QuickAssetSaver/panels/manage_panel.py
@@ -1,4 +1,6 @@
-﻿import bpy
+﻿import time
+
+import bpy
 from ..compatibility import is_asset_browser_active, is_protected_library
 
 
@@ -123,6 +125,7 @@ class QAM_PT_asset_actions(bpy.types.Panel):
         if manage:
             box.prop(manage, "move_target_library", text="Library")
             box.prop(manage, "move_target_catalog", text="Catalog")
+            box.prop(manage, "move_conflict_resolution", text="If Exists")
         move_row = box.row()
         move_row.scale_y = 1.2
         move_row.operator(
@@ -130,6 +133,13 @@ class QAM_PT_asset_actions(bpy.types.Panel):
             text="Move Asset",
             icon="EXPORT",
         )
+
+        if manage is not None and manage.show_success_message:
+            if time.time() - manage.success_message_time < 4.0:
+                success_box = box.box()
+                success_box.label(text="Moved!", icon="CHECKMARK")
+            else:
+                manage.show_success_message = False
 
         # Delete section
         layout.separator()

--- a/QuickAssetSaver/panels/manage_panel.py
+++ b/QuickAssetSaver/panels/manage_panel.py
@@ -1,0 +1,160 @@
+﻿import bpy
+from ..compatibility import is_asset_browser_active, is_protected_library
+
+
+def _count_selected_assets(context):
+    if hasattr(context, "selected_asset_files") and context.selected_asset_files is not None:
+        return len(context.selected_asset_files)
+    elif hasattr(context, "selected_assets") and context.selected_assets is not None:
+        return len(context.selected_assets)
+    elif hasattr(context.space_data, "files"):
+        try:
+            return len([f for f in context.space_data.files if getattr(f, "select", False)])
+        except (AttributeError, TypeError):
+            pass
+    return 0
+
+
+class QAM_UL_metadata_tags(bpy.types.UIList):
+    bl_idname = "QAM_UL_metadata_tags"
+
+    def draw_item(self, context, layout, data, item, icon, active_data, active_propname, index):
+        layout.prop(item, "name", text="", emboss=False, icon='NONE')
+
+
+class QAM_OT_tag_add(bpy.types.Operator):
+    bl_idname = "qam.tag_add"
+    bl_label = "Add Tag"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        return hasattr(context.window_manager, "qam_metadata_edit")
+
+    def execute(self, context):
+        meta = context.window_manager.qam_metadata_edit
+        tag = meta.edit_tags.add()
+        tag.name = "Tag"
+        meta.active_tag_index = len(meta.edit_tags) - 1
+        return {'FINISHED'}
+
+
+class QAM_OT_tag_remove(bpy.types.Operator):
+    bl_idname = "qam.tag_remove"
+    bl_label = "Remove Tag"
+    bl_options = {'REGISTER', 'UNDO'}
+
+    @classmethod
+    def poll(cls, context):
+        wm = context.window_manager
+        if not hasattr(wm, "qam_metadata_edit"):
+            return False
+        meta = wm.qam_metadata_edit
+        return len(meta.edit_tags) > 0 and meta.active_tag_index >= 0
+
+    def execute(self, context):
+        meta = context.window_manager.qam_metadata_edit
+        if meta.active_tag_index < len(meta.edit_tags):
+            meta.edit_tags.remove(meta.active_tag_index)
+            if meta.active_tag_index >= len(meta.edit_tags) and meta.active_tag_index > 0:
+                meta.active_tag_index -= 1
+        return {'FINISHED'}
+
+
+class QAM_PT_asset_actions(bpy.types.Panel):
+    bl_idname = "QAM_PT_asset_actions"
+    bl_space_type = 'FILE_BROWSER'
+    bl_region_type = 'TOOL_PROPS'
+    bl_label = "Actions"
+    bl_order = 60
+
+    @classmethod
+    def poll(cls, context):
+        if not is_asset_browser_active(context):
+            return False
+        if not context.asset:
+            return False
+        if context.asset.local_id is not None:
+            return False
+        if _count_selected_assets(context) >= 2:
+            return False
+        return True
+
+    def draw(self, context):
+        from .. import panels as panels_pkg
+        panels_pkg._check_and_exit_edit_mode(context)
+
+        layout = self.layout
+        layout.enabled = not is_protected_library(context)
+
+        wm = context.window_manager
+        manage = getattr(wm, "qam_manage_props", None)
+        meta = getattr(wm, "qam_metadata_edit", None)
+
+        # Edit mode toggle
+        edit_row = layout.row()
+        edit_row.scale_y = 1.3
+        if panels_pkg._edit_mode_active:
+            edit_row.operator(
+                "qam.toggle_edit_mode",
+                text="Cancel",
+                icon="PANEL_CLOSE",
+                depress=True,
+            )
+            apply_row = layout.row()
+            apply_row.scale_y = 1.3
+            apply_row.enabled = meta.has_changes() if meta else False
+            apply_row.operator(
+                "qam.apply_metadata_changes",
+                text="Apply Changes",
+                icon="CHECKMARK",
+            )
+        else:
+            edit_row.operator(
+                "qam.toggle_edit_mode",
+                text="Edit Metadata/Tags",
+                icon="GREASEPENCIL",
+            )
+
+        # Move section
+        layout.separator()
+        layout.label(text="Move", icon="ASSET_MANAGER")
+        box = layout.box()
+        if manage:
+            box.prop(manage, "move_target_library", text="Library")
+            box.prop(manage, "move_target_catalog", text="Catalog")
+        move_row = box.row()
+        move_row.scale_y = 1.2
+        move_row.operator(
+            "qam.move_selected_to_library",
+            text="Move Asset",
+            icon="EXPORT",
+        )
+
+        # Delete section
+        layout.separator()
+        delete_row = layout.row()
+        delete_row.scale_y = 1.2
+        delete_row.operator(
+            "qam.delete_selected_assets",
+            text="Remove Asset from Library",
+            icon="TRASH",
+        )
+
+
+classes = (
+    QAM_UL_metadata_tags,
+    QAM_OT_tag_add,
+    QAM_OT_tag_remove,
+    QAM_PT_asset_actions,
+)
+
+
+def register():
+    for cls in classes:
+        bpy.utils.register_class(cls)
+
+
+def unregister():
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/QuickAssetSaver/panels/save_panel.py
+++ b/QuickAssetSaver/panels/save_panel.py
@@ -1,0 +1,108 @@
+﻿import time
+import bpy
+
+from ..compatibility import is_asset_browser_active
+from ..properties import get_library_by_identifier
+
+
+def _count_selected_assets(context):
+    if hasattr(context, "selected_asset_files") and context.selected_asset_files is not None:
+        return len(context.selected_asset_files)
+    elif hasattr(context, "selected_assets") and context.selected_assets is not None:
+        return len(context.selected_assets)
+    elif hasattr(context.space_data, "files"):
+        try:
+            return len([f for f in context.space_data.files if getattr(f, "select", False)])
+        except (AttributeError, TypeError):
+            pass
+    return 0
+
+
+class QAM_PT_save_to_library(bpy.types.Panel):
+    bl_idname = "QAM_PT_save_to_library"
+    bl_label = "Save to Library"
+    bl_space_type = "FILE_BROWSER"
+    bl_region_type = "TOOL_PROPS"
+    bl_order = 100
+
+    @classmethod
+    def poll(cls, context):
+        if not is_asset_browser_active(context):
+            return False
+        asset = getattr(context, "asset", None)
+        if asset is None:
+            return False
+        if getattr(asset, "local_id", None) is None:
+            return False
+        if _count_selected_assets(context) >= 2:
+            return False
+        return True
+
+    def draw(self, context):
+        layout = self.layout
+        props = context.window_manager.qam_save_props
+        asset = context.asset
+
+        # Library dropdown
+        layout.prop(props, "selected_library", text="Library")
+
+        # Catalog dropdown row with refresh button
+        # Disabled when "Copy Catalog from Current File" is on
+        catalog_row = layout.row(align=True)
+        catalog_row.enabled = not props.auto_create_catalog
+        catalog_row.prop(props, "catalog", text="Catalog")
+        catalog_row.operator("qam.refresh_catalog_list", icon="FILE_REFRESH", text="")
+        row = layout.row()
+        row.scale_y = 0.85
+        row.prop(props, "auto_create_catalog")
+
+        # Path preview
+        if props.selected_library and props.selected_library != "NONE":
+            lib = get_library_by_identifier(props.selected_library)
+            if lib is not None:
+                path = lib.path if hasattr(lib, "path") else str(lib)
+                if len(path) > 35:
+                    path_display = path[:12] + "..." + path[-20:]
+                else:
+                    path_display = path
+                layout.label(text=path_display, icon="FILE_FOLDER")
+
+        # Collection warning
+        if asset.local_id is not None and isinstance(asset.local_id, bpy.types.Collection):
+            box = layout.box()
+            box.label(text="Collection previews may need", icon="INFO")
+            box.label(text="regeneration after saving.")
+
+        # Success message
+        if props.show_success_message:
+            if time.time() - props.success_message_time < 4.0:
+                box = layout.box()
+                col = box.column()
+                col.alert = True
+                col.label(text="Saved!", icon="CHECKMARK")
+            else:
+                props.show_success_message = False
+
+        layout.separator()
+
+        # Save button
+        row = layout.row()
+        row.scale_y = 1.3
+        row.operator("qam.save_asset_to_library_direct", text="Copy to Asset Library", icon="EXPORT")
+
+        # Open folder button
+        row = layout.row()
+        row.operator("qam.open_library_folder")
+
+
+classes = (QAM_PT_save_to_library,)
+
+
+def register():
+    for cls in classes:
+        bpy.utils.register_class(cls)
+
+
+def unregister():
+    for cls in reversed(classes):
+        bpy.utils.unregister_class(cls)

--- a/QuickAssetSaver/panels/save_panel.py
+++ b/QuickAssetSaver/panels/save_panel.py
@@ -52,9 +52,7 @@ class QAM_PT_save_to_library(bpy.types.Panel):
         catalog_row.enabled = not props.auto_create_catalog
         catalog_row.prop(props, "catalog", text="Catalog")
         catalog_row.operator("qam.refresh_catalog_list", icon="FILE_REFRESH", text="")
-        row = layout.row()
-        row.scale_y = 0.85
-        row.prop(props, "auto_create_catalog")
+        layout.prop(props, "auto_create_catalog")
 
         # Path preview
         if props.selected_library and props.selected_library != "NONE":
@@ -77,9 +75,7 @@ class QAM_PT_save_to_library(bpy.types.Panel):
         if props.show_success_message:
             if time.time() - props.success_message_time < 4.0:
                 box = layout.box()
-                col = box.column()
-                col.alert = True
-                col.label(text="Saved!", icon="CHECKMARK")
+                box.label(text="Saved!", icon="CHECKMARK")
             else:
                 props.show_success_message = False
 
@@ -92,7 +88,7 @@ class QAM_PT_save_to_library(bpy.types.Panel):
 
         # Open folder button
         row = layout.row()
-        row.operator("qam.open_library_folder")
+        row.operator("qam.open_library_folder", icon="FILE_FOLDER")
 
 
 classes = (QAM_PT_save_to_library,)

--- a/QuickAssetSaver/properties.py
+++ b/QuickAssetSaver/properties.py
@@ -11,7 +11,7 @@ from bpy.types import AddonPreferences, PropertyGroup
 
 MAX_FILENAME_AFFIX_LENGTH = 32
 NONE_LIBRARY_IDENTIFIER = "NONE"
-DEBUG_MODE = False
+DEBUG_MODE = bpy.app.debug
 
 # Must cache enum items or Blender garbage-collects strings before display
 _LIBRARY_ENUM_CACHE = []

--- a/QuickAssetSaver/properties.py
+++ b/QuickAssetSaver/properties.py
@@ -78,6 +78,12 @@ def build_library_enum_items():
             for idx, lib in enumerate(asset_libs):
                 try:
                     if hasattr(lib, "name") and hasattr(lib, "path") and lib.path:
+                        # In Blender 5.2+, Essentials and All Libraries appear as entries
+                        # in this list. Only include user-configured (CUSTOM type) libraries.
+                        lib_type = getattr(lib, 'type', 'CUSTOM')
+                        if lib_type != 'CUSTOM':
+                            continue
+
                         # Skip libraries the user has disabled (checks known attribute names across versions)
                         if not getattr(lib, 'is_enabled', getattr(lib, 'enabled', True)):
                             continue

--- a/QuickAssetSaver/properties.py
+++ b/QuickAssetSaver/properties.py
@@ -396,17 +396,6 @@ class QAMSaveProperties(PropertyGroup):
         default="",
     )
 
-    conflict_resolution: EnumProperty(
-        name="Overwrite",
-        description="What to do if a file with the same name already exists",
-        items=[
-            ("INCREMENT", "Increment", "Save as Name_001.blend, etc.", "DUPLICATE", 0),
-            ("OVERWRITE", "Overwrite", "Replace the existing file", "FILE_REFRESH", 1),
-            ("CANCEL", "Cancel", "Don't save if file exists", "CANCEL", 2),
-        ],
-        default="INCREMENT",
-    )
-
     show_success_message: BoolProperty(
         name="Show Success Message",
         description="Internal flag to show thank you message after save",
@@ -607,6 +596,20 @@ class QAMManageProperties(PropertyGroup):
             ("CANCEL", "Skip", "Skip files that already exist", "CANCEL", 2),
         ],
         default="INCREMENT",
+    )
+
+    show_success_message: BoolProperty(
+        name="Show Success Message",
+        description="Internal flag to show confirmation message after move",
+        default=False,
+        options={"SKIP_SAVE", "HIDDEN"},
+    )
+
+    success_message_time: bpy.props.FloatProperty(
+        name="Success Message Time",
+        description="Timestamp when success message was shown",
+        default=0.0,
+        options={"SKIP_SAVE", "HIDDEN"},
     )
 
 

--- a/QuickAssetSaver/properties.py
+++ b/QuickAssetSaver/properties.py
@@ -1,4 +1,4 @@
-"""
+﻿"""
 Properties Module - Quick Asset Saver
 ======================================
 Defines addon preferences, property groups, and configuration management.
@@ -78,8 +78,10 @@ def build_library_enum_items():
             for idx, lib in enumerate(asset_libs):
                 try:
                     if hasattr(lib, "name") and hasattr(lib, "path") and lib.path:
-                        # Get library name - handle potential encoding issues gracefully
-                        # Ensure we properly handle Unicode in all languages (Chinese, Japanese, Korean, etc.)
+                        # Skip libraries the user has disabled (checks known attribute names across versions)
+                        if not getattr(lib, 'is_enabled', getattr(lib, 'enabled', True)):
+                            continue
+
                         try:
                             lib_name = str(lib.name) if lib.name else f"Library {idx + 1}"
                         except (UnicodeDecodeError, UnicodeEncodeError, AttributeError, TypeError):
@@ -93,7 +95,7 @@ def build_library_enum_items():
                         # Display name uses the full Unicode library name
                         display_name = lib_name
                         
-                        debug_print(f"[QAS Enum Debug] Adding library {idx}: id=LIB_{idx}, name={display_name}, path={lib_path}")
+                        debug_print(f"[QAM Enum Debug] Adding library {idx}: id=LIB_{idx}, name={display_name}, path={lib_path}")
                         
                         items.append(
                             (
@@ -101,7 +103,7 @@ def build_library_enum_items():
                                 display_name,
                                 f"Save to: {lib_path}",
                                 "ASSET_MANAGER",
-                                idx,
+                                len(items),  # sequential value so 0 is always the first visible library
                             )
                         )
                 except (AttributeError, UnicodeDecodeError, TypeError) as e:
@@ -122,7 +124,7 @@ def build_library_enum_items():
         )
 
     _LIBRARY_ENUM_CACHE = items
-    debug_print(f"[QAS Enum Debug] Cached {len(_LIBRARY_ENUM_CACHE)} library items")
+    debug_print(f"[QAM Enum Debug] Cached {len(_LIBRARY_ENUM_CACHE)} library items")
     return _LIBRARY_ENUM_CACHE
 
 
@@ -139,7 +141,7 @@ def validate_string_length(value, max_length, property_name):
     return value
 
 
-class QuickAssetSaverPreferences(AddonPreferences):
+class QuickAssetManagerPreferences(AddonPreferences):
     bl_idname = __package__
 
     def get_preference_libraries(self, context):
@@ -274,7 +276,7 @@ class QuickAssetSaverPreferences(AddonPreferences):
         layout.prop(self, "max_bundle_size_mb")
 
 
-class QASSaveProperties(PropertyGroup):
+class QAMSaveProperties(PropertyGroup):
     def get_asset_libraries(self, context):
         return build_library_enum_items()
 
@@ -350,6 +352,12 @@ class QASSaveProperties(PropertyGroup):
         name="Catalog",
         description="Catalog to assign the asset to",
         items=get_catalogs,
+    )
+
+    auto_create_catalog: BoolProperty(
+        name="Copy Catalog from Current File",
+        description="Use this asset's existing catalog from the Current File. If that catalog does not exist in the target library it will be created automatically. The catalog dropdown is ignored when this is enabled",
+        default=False,
     )
 
     asset_description: StringProperty(
@@ -490,7 +498,7 @@ def _initialize_default_library(addon_prefs, preferences):
         print(f"Warning: Could not initialize default library: {e}")
 
 
-class QAS_BundlerProperties(PropertyGroup):
+class QAMBundlerProperties(PropertyGroup):
     output_name: StringProperty(
         name="Bundle Name",
         description="Base name for the bundle file (date will be appended automatically)",
@@ -543,7 +551,7 @@ class QAS_BundlerProperties(PropertyGroup):
     )
 
 
-class QAS_ManageProperties(PropertyGroup):
+class QAMManageProperties(PropertyGroup):
     def get_target_libraries(self, context):
         return build_library_enum_items()
 
@@ -596,7 +604,7 @@ class QAS_ManageProperties(PropertyGroup):
     )
 
 
-class QAS_TagItem(bpy.types.PropertyGroup):
+class QAMTagItem(bpy.types.PropertyGroup):
     name: StringProperty(
         name="Tag",
         description="Tag name",
@@ -604,7 +612,7 @@ class QAS_TagItem(bpy.types.PropertyGroup):
     )
 
 
-class QAS_MetadataEditProperties(bpy.types.PropertyGroup):
+class QAMMetadataEditProperties(bpy.types.PropertyGroup):
     source_file: StringProperty(
         name="Source File",
         description="Path to the .blend file containing this asset",
@@ -650,7 +658,7 @@ class QAS_MetadataEditProperties(bpy.types.PropertyGroup):
     )
     
     edit_tags: CollectionProperty(
-        type=QAS_TagItem,
+        type=QAMTagItem,
         name="Tags",
         description="Tags for this asset",
     )
@@ -720,40 +728,40 @@ class QAS_MetadataEditProperties(bpy.types.PropertyGroup):
 
 
 classes = (
-    QuickAssetSaverPreferences,
-    QASSaveProperties,
-    QAS_BundlerProperties,
-    QAS_ManageProperties,
-    QAS_TagItem,  # Must be registered before QAS_MetadataEditProperties
-    QAS_MetadataEditProperties,
+    QuickAssetManagerPreferences,
+    QAMSaveProperties,
+    QAMBundlerProperties,
+    QAMManageProperties,
+    QAMTagItem,  # Must be registered before QAMMetadataEditProperties
+    QAMMetadataEditProperties,
 )
 
 
 def register():
     for cls in classes:
         bpy.utils.register_class(cls)
-    bpy.types.WindowManager.qas_save_props = bpy.props.PointerProperty(
-        type=QASSaveProperties
+    bpy.types.WindowManager.qam_save_props = bpy.props.PointerProperty(
+        type=QAMSaveProperties
     )
-    bpy.types.WindowManager.qas_bundler_props = bpy.props.PointerProperty(
-        type=QAS_BundlerProperties
+    bpy.types.WindowManager.qam_bundler_props = bpy.props.PointerProperty(
+        type=QAMBundlerProperties
     )
-    bpy.types.WindowManager.qas_manage_props = bpy.props.PointerProperty(
-        type=QAS_ManageProperties
+    bpy.types.WindowManager.qam_manage_props = bpy.props.PointerProperty(
+        type=QAMManageProperties
     )
-    bpy.types.WindowManager.qas_metadata_edit = bpy.props.PointerProperty(
-        type=QAS_MetadataEditProperties
+    bpy.types.WindowManager.qam_metadata_edit = bpy.props.PointerProperty(
+        type=QAMMetadataEditProperties
     )
 
 
 def unregister():
-    if hasattr(bpy.types.WindowManager, "qas_metadata_edit"):
-        del bpy.types.WindowManager.qas_metadata_edit
-    if hasattr(bpy.types.WindowManager, "qas_bundler_props"):
-        del bpy.types.WindowManager.qas_bundler_props
-    if hasattr(bpy.types.WindowManager, "qas_save_props"):
-        del bpy.types.WindowManager.qas_save_props
-    if hasattr(bpy.types.WindowManager, "qas_manage_props"):
-        del bpy.types.WindowManager.qas_manage_props
+    if hasattr(bpy.types.WindowManager, "qam_metadata_edit"):
+        del bpy.types.WindowManager.qam_metadata_edit
+    if hasattr(bpy.types.WindowManager, "qam_bundler_props"):
+        del bpy.types.WindowManager.qam_bundler_props
+    if hasattr(bpy.types.WindowManager, "qam_save_props"):
+        del bpy.types.WindowManager.qam_save_props
+    if hasattr(bpy.types.WindowManager, "qam_manage_props"):
+        del bpy.types.WindowManager.qam_manage_props
     for cls in reversed(classes):
         bpy.utils.unregister_class(cls)

--- a/run_tests.ps1
+++ b/run_tests.ps1
@@ -1,0 +1,41 @@
+<#
+.SYNOPSIS
+    Run the Quick Asset Manager test suite inside Blender.
+.DESCRIPTION
+    Launches Blender in background mode with the test runner script.
+    Blender must be on PATH, or set $env:BLENDER_EXE to the full path.
+.EXAMPLE
+    .\run_tests.ps1
+    .\run_tests.ps1 -Verbose
+#>
+param(
+    [switch]$Verbose
+)
+
+$ErrorActionPreference = "Stop"
+
+$BlenderExe = if ($env:BLENDER_EXE) { $env:BLENDER_EXE } else { "blender" }
+$TestRunner  = Join-Path $PSScriptRoot "tests\blender_test_runner.py"
+
+if (-not (Test-Path $TestRunner)) {
+    Write-Error "Test runner not found at: $TestRunner"
+    exit 1
+}
+
+Write-Host ""
+Write-Host "Quick Asset Manager - Test Suite" -ForegroundColor Cyan
+Write-Host "Runner : $TestRunner"
+Write-Host "Blender: $BlenderExe"
+Write-Host ""
+
+$blenderArgs = @(
+    "--background",
+    "--python", $TestRunner
+)
+
+if ($Verbose) {
+    $blenderArgs += "--verbose"
+}
+
+& $BlenderExe @blenderArgs
+exit $LASTEXITCODE

--- a/run_tests_all_versions.ps1
+++ b/run_tests_all_versions.ps1
@@ -1,0 +1,87 @@
+<#
+.SYNOPSIS
+    Run the Quick Asset Manager test suite across every supported Blender version.
+.DESCRIPTION
+    Opt-in only — this is NOT part of the normal test loop (use .\run_tests.ps1
+    for that). Runs tests/blender_test_runner.py against each locally installed
+    Blender version and prints a per-version pass/fail summary at the end.
+
+    Looks for versions under "C:\Program Files\Blender Foundation" by default;
+    override with -BlenderFoundationRoot if installed elsewhere. Missing
+    versions are skipped with a warning rather than failing the whole run.
+.EXAMPLE
+    .\run_tests_all_versions.ps1
+    .\run_tests_all_versions.ps1 -BlenderFoundationRoot "D:\Blender"
+#>
+param(
+    [string]$BlenderFoundationRoot = "C:\Program Files\Blender Foundation"
+)
+
+$ErrorActionPreference = "Continue"
+
+$TestRunner = Join-Path $PSScriptRoot "tests\blender_test_runner.py"
+if (-not (Test-Path $TestRunner)) {
+    Write-Error "Test runner not found at: $TestRunner"
+    exit 1
+}
+
+# Map each supported Blender version to its executable, relative to $BlenderFoundationRoot.
+$Versions = [ordered]@{
+    "4.2" = "Blender 4.2 LTS\blender.exe"
+    "4.3" = "Blender 4.3\blender.exe"
+    "4.5" = "Blender 4.5\blender.exe"
+    "5.0" = "Blender 5.0\blender.exe"
+    "5.1" = "Blender 5.1\blender.exe"
+    "5.2" = "blender-5.2.0-alpha+main.33045d0bf4e8-windows.amd64-release\blender.exe"
+}
+
+Write-Host ""
+Write-Host "Quick Asset Manager - Multi-Version Test Suite" -ForegroundColor Cyan
+Write-Host "Runner : $TestRunner"
+Write-Host "Root   : $BlenderFoundationRoot"
+Write-Host ""
+
+$results = [ordered]@{}
+
+foreach ($version in $Versions.Keys) {
+    $exe = Join-Path $BlenderFoundationRoot $Versions[$version]
+
+    if (-not (Test-Path $exe)) {
+        Write-Host "[$version] SKIPPED - not found at $exe" -ForegroundColor Yellow
+        $results[$version] = "SKIPPED"
+        continue
+    }
+
+    Write-Host "----------------------------------------------------------------------"
+    Write-Host "[$version] Running via $exe" -ForegroundColor Cyan
+    Write-Host "----------------------------------------------------------------------"
+
+    & $exe --background --python $TestRunner
+    $exitCode = $LASTEXITCODE
+
+    if ($exitCode -eq 0) {
+        $results[$version] = "PASSED"
+    } else {
+        $results[$version] = "FAILED (exit $exitCode)"
+    }
+    Write-Host ""
+}
+
+Write-Host "======================================================================"
+Write-Host "  Summary" -ForegroundColor Cyan
+Write-Host "======================================================================"
+
+$anyFailed = $false
+foreach ($version in $results.Keys) {
+    $status = $results[$version]
+    $color = switch -Wildcard ($status) {
+        "PASSED"   { "Green" }
+        "SKIPPED"  { "Yellow" }
+        default    { $anyFailed = $true; "Red" }
+    }
+    Write-Host ("  Blender {0,-6} {1}" -f $version, $status) -ForegroundColor $color
+}
+Write-Host "======================================================================"
+Write-Host ""
+
+exit ($(if ($anyFailed) { 1 } else { 0 }))

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,0 +1,1 @@
+# Test package for Quick Asset Manager

--- a/tests/blender_test_runner.py
+++ b/tests/blender_test_runner.py
@@ -25,7 +25,6 @@ import bpy  # noqa: E402 (must come after sys.path setup)
 
 def _register_addon():
     """Register the addon if it is not already active (i.e. not installed)."""
-    import bpy
     # If the addon is installed as a Blender extension it is already registered
     # before this script runs. Check for any of its WindowManager attributes.
     if hasattr(bpy.types.WindowManager, "qam_save_props"):
@@ -41,7 +40,6 @@ def _register_addon():
 
 def _unregister_addon():
     """Unregister only if we registered manually (i.e. addon is NOT installed)."""
-    import bpy
     # If the addon was already registered by Blender's extension system,
     # let Blender manage unregistration — calling it here would double-unregister.
     if "QuickAssetSaver" in (getattr(bpy.context.preferences.addons, "keys", lambda: [])() if hasattr(bpy.context.preferences.addons, "keys") else []):

--- a/tests/blender_test_runner.py
+++ b/tests/blender_test_runner.py
@@ -1,0 +1,89 @@
+"""
+Blender test runner for Quick Asset Manager.
+
+Run with:
+    blender --background --python tests/blender_test_runner.py
+
+Or via the PowerShell launcher:
+    .\run_tests.ps1
+"""
+
+import sys
+import unittest
+from pathlib import Path
+
+# ── Path setup ────────────────────────────────────────────────────────────────
+# Add the project root so `import QuickAssetSaver` works.
+PROJECT_ROOT = Path(__file__).resolve().parent.parent
+if str(PROJECT_ROOT) not in sys.path:
+    sys.path.insert(0, str(PROJECT_ROOT))
+
+TESTS_DIR = Path(__file__).resolve().parent
+
+# ── Addon registration ─────────────────────────────────────────────────────────
+import bpy  # noqa: E402 (must come after sys.path setup)
+
+def _register_addon():
+    """Register the addon if it is not already active (i.e. not installed)."""
+    import bpy
+    # If the addon is installed as a Blender extension it is already registered
+    # before this script runs. Check for any of its WindowManager attributes.
+    if hasattr(bpy.types.WindowManager, "qam_save_props"):
+        print("[QAM Tests] Addon already registered (installed extension) — skipping manual register.")
+        return
+    import QuickAssetSaver
+    try:
+        QuickAssetSaver.register()
+        print("[QAM Tests] Addon registered (source import).")
+    except Exception as e:
+        print(f"[QAM Tests] WARNING: Could not register addon: {e}")
+
+
+def _unregister_addon():
+    """Unregister only if we registered manually (i.e. addon is NOT installed)."""
+    import bpy
+    # If the addon was already registered by Blender's extension system,
+    # let Blender manage unregistration — calling it here would double-unregister.
+    if "QuickAssetSaver" in (getattr(bpy.context.preferences.addons, "keys", lambda: [])() if hasattr(bpy.context.preferences.addons, "keys") else []):
+        print("[QAM Tests] Installed extension — skipping manual unregister.")
+        return
+    # Check if it was actually registered by us by looking for a known installed path
+    import QuickAssetSaver
+    addon_file = getattr(QuickAssetSaver, "__file__", "")
+    if "extensions" in addon_file.replace("\\", "/"):
+        print("[QAM Tests] Installed extension detected — skipping manual unregister.")
+        return
+    try:
+        QuickAssetSaver.unregister()
+        print("[QAM Tests] Addon unregistered.")
+    except Exception as e:
+        print(f"[QAM Tests] WARNING: Could not unregister addon (normal in test env): {e}")
+
+# ── Test discovery and execution ───────────────────────────────────────────────
+def main():
+    _register_addon()
+
+    loader = unittest.TestLoader()
+    suite = loader.discover(start_dir=str(TESTS_DIR), pattern="test_*.py")
+
+    print("\n" + "=" * 70)
+    print("  Quick Asset Manager — Test Suite")
+    print("=" * 70 + "\n")
+
+    runner = unittest.TextTestRunner(verbosity=2, stream=sys.stdout)
+    result = runner.run(suite)
+
+    print("\n" + "=" * 70)
+    passed  = result.testsRun - len(result.failures) - len(result.errors) - len(result.skipped)
+    print(f"  {passed}/{result.testsRun} passed  |  "
+          f"{len(result.failures)} failed  |  "
+          f"{len(result.errors)} errors  |  "
+          f"{len(result.skipped)} skipped")
+    print("=" * 70 + "\n")
+
+    _unregister_addon()
+    sys.exit(0 if result.wasSuccessful() else 1)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -1,0 +1,138 @@
+"""
+Shared test fixtures and helpers for the QAM test suite.
+All helpers here work inside a running Blender instance.
+"""
+
+import tempfile
+import shutil
+import uuid
+from pathlib import Path
+
+
+# ── Temporary library helper ───────────────────────────────────────────────────
+
+class TempLibrary:
+    """
+    Context manager that creates a temporary directory laid out like a
+    Blender asset library (with an optional blender_assets.cats.txt).
+
+    Usage::
+
+        with TempLibrary() as lib:
+            lib.add_catalog("Materials/Metal")
+            path = lib.path
+    """
+
+    def __init__(self, catalogs=None):
+        """
+        Args:
+            catalogs: optional list of catalog path strings to pre-populate,
+                      e.g. ["Materials/Metal", "Characters/Heroes"]
+        """
+        self._tmpdir = None
+        self._initial_catalogs = catalogs or []
+
+    def __enter__(self):
+        self._tmpdir = tempfile.mkdtemp(prefix="qam_test_lib_")
+        self.path = Path(self._tmpdir)
+        self.cdf_path = self.path / "blender_assets.cats.txt"
+
+        lines = ["VERSION 1", ""]
+        self._catalog_map = {}  # path → uuid
+
+        for cat_path in self._initial_catalogs:
+            cat_uuid = str(uuid.uuid4())
+            self._catalog_map[cat_path] = cat_uuid
+            display = cat_path.split("/")[-1]
+            lines.append(f"{cat_uuid}:{cat_path}:{display}")
+
+        self.cdf_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+        return self
+
+    def __exit__(self, *_):
+        if self._tmpdir:
+            shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def add_catalog(self, catalog_path: str) -> str:
+        """Add a catalog entry and return its UUID."""
+        cat_uuid = str(uuid.uuid4())
+        self._catalog_map[catalog_path] = cat_uuid
+        display = catalog_path.split("/")[-1]
+        with open(self.cdf_path, "a", encoding="utf-8") as f:
+            f.write(f"{cat_uuid}:{catalog_path}:{display}\n")
+        return cat_uuid
+
+    def uuid_for(self, catalog_path: str) -> str:
+        """Return the UUID assigned to a pre-created catalog path."""
+        return self._catalog_map[catalog_path]
+
+
+# ── Mock Blender context helpers ───────────────────────────────────────────────
+
+class MockParams:
+    """Minimal stand-in for space_data.params."""
+    def __init__(self, lib_ref=None):
+        self.asset_library_reference = lib_ref
+
+
+class MockSpace:
+    """Minimal stand-in for context.space_data."""
+    def __init__(self, space_type="FILE_BROWSER", browse_mode="ASSETS", lib_ref=None):
+        self.type = space_type
+        self.browse_mode = browse_mode
+        self.params = MockParams(lib_ref) if lib_ref is not None else None
+
+
+class MockContext:
+    """Minimal stand-in for bpy.context."""
+    def __init__(self, space_data=None):
+        self.space_data = space_data
+
+
+def make_asset_browser_context(lib_ref="My Library"):
+    """Return a MockContext that looks like an Asset Browser showing lib_ref."""
+    return MockContext(MockSpace(lib_ref=lib_ref))
+
+
+# ── Mock addon preferences ─────────────────────────────────────────────────────
+
+class MockPrefs:
+    """Minimal stand-in for QuickAssetManagerPreferences."""
+    filename_prefix: str = ""
+    filename_suffix: str = ""
+    include_date_in_filename: bool = False
+    use_catalog_subfolders: bool = True
+    auto_refresh: bool = True
+    max_bundle_size_mb: int = 4096
+    default_author: str = ""
+    default_description: str = ""
+    default_license: str = ""
+    default_copyright: str = ""
+
+
+# ── Blender datablock helpers ──────────────────────────────────────────────────
+
+def make_test_asset(name="QAM_TestAsset", description="", author=""):
+    """
+    Create a simple mesh object, mark it as an asset, and return it.
+    Caller is responsible for cleanup via bpy.data.objects.remove(...).
+    """
+    import bpy
+    bpy.ops.mesh.primitive_cube_add()
+    obj = bpy.context.active_object
+    obj.name = name
+    obj.asset_mark()
+    if description:
+        obj.asset_data.description = description
+    if author:
+        obj.asset_data.author = author
+    return obj
+
+
+def remove_test_asset(obj):
+    """Remove a test asset object and its mesh from bpy.data."""
+    import bpy
+    mesh = obj.data if obj.type == 'MESH' else None
+    bpy.data.objects.remove(obj, do_unlink=True)
+    if mesh and mesh.users == 0:
+        bpy.data.meshes.remove(mesh)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -136,3 +136,71 @@ def remove_test_asset(obj):
     bpy.data.objects.remove(obj, do_unlink=True)
     if mesh and mesh.users == 0:
         bpy.data.meshes.remove(mesh)
+
+
+def make_compositor_asset(name="QAM_CompositorTest", scene_name="QAM_CompositorTest_Scene"):
+    """
+    Create a compositor node group asset containing a Render Layer node
+    that points at a dedicated Scene, and mark the node group as an asset.
+
+    Mirrors the real-world setup that triggers the "whole project copied"
+    bug (issue #14): a Render Layer node holds a direct pointer to a Scene,
+    which bpy.data.libraries.write() will otherwise pull in wholesale.
+
+    A Render Layers node can only live in "the compositing node tree of a
+    scene in the file" (a hard restriction enforced by Blender itself, not
+    just newer versions), so the node tree we mark as an asset must be a
+    scene's own compositor tree rather than a free-floating node group.
+    ensure_scene_compositor_node_tree() handles both the pre-5.2 API
+    (scene.use_nodes / scene.node_tree) and 5.2+ (scene.compositing_node_group).
+
+    Returns (node_tree, scene, owner_scene). Caller is responsible for
+    cleanup via remove_compositor_asset(node_tree, scene, owner_scene).
+    """
+    import bpy
+    from QuickAssetSaver.compatibility import ensure_scene_compositor_node_tree
+    owner_scene = bpy.data.scenes.new(f"{name}_Owner")
+    node_tree = ensure_scene_compositor_node_tree(owner_scene)
+
+    scene = bpy.data.scenes.new(scene_name)
+    # Give the scene something non-trivial so an accidental copy is detectable.
+    bpy.ops.mesh.primitive_cube_add()
+    cube = bpy.context.active_object
+    for coll in list(cube.users_collection):
+        coll.objects.unlink(cube)
+    scene.collection.objects.link(cube)
+
+    render_layers_node = next(
+        (n for n in node_tree.nodes if n.bl_idname == 'CompositorNodeRLayers'), None
+    )
+    if render_layers_node is None:
+        render_layers_node = node_tree.nodes.new('CompositorNodeRLayers')
+    render_layers_node.scene = scene
+
+    node_tree.asset_mark()
+    return node_tree, scene, owner_scene
+
+
+def remove_compositor_asset(node_tree, scene, owner_scene):
+    """Remove a compositor node group asset and its associated scenes/objects."""
+    import bpy
+    for obj in list(scene.collection.objects):
+        mesh = obj.data if obj.type == 'MESH' else None
+        bpy.data.objects.remove(obj, do_unlink=True)
+        if mesh and mesh.users == 0:
+            bpy.data.meshes.remove(mesh)
+    bpy.data.scenes.remove(scene)
+    # asset_mark() sets a fake user, which would otherwise keep the node
+    # tree alive indefinitely — clear it either way.
+    node_tree.use_fake_user = False
+    try:
+        # Blender 5.2+: the compositor tree is a standalone bpy.data.node_groups
+        # entry, so it must be removed explicitly (do_unlink clears
+        # owner_scene's pointer to it).
+        bpy.data.node_groups.remove(node_tree, do_unlink=True)
+    except RuntimeError:
+        # Older Blender versions embed the compositor tree in the scene
+        # (not a standalone bpy.data.node_groups entry) — it's freed
+        # automatically when the owning scene is removed below.
+        pass
+    bpy.data.scenes.remove(owner_scene)

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -166,6 +166,7 @@ def make_compositor_asset(name="QAM_CompositorTest", scene_name="QAM_CompositorT
     # Give the scene something non-trivial so an accidental copy is detectable.
     bpy.ops.mesh.primitive_cube_add()
     cube = bpy.context.active_object
+    assert cube is not None
     for coll in list(cube.users_collection):
         coll.objects.unlink(cube)
     scene.collection.objects.link(cube)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,0 +1,198 @@
+"""Tests for catalog CDF read/write operations."""
+import unittest
+import uuid
+import tempfile
+import shutil
+from pathlib import Path
+from QuickAssetSaver.operators.catalog import (
+    get_catalogs_from_cdf,
+    get_catalog_path_from_uuid,
+    create_catalog_entry,
+    clear_catalog_cache,
+)
+from tests.fixtures import TempLibrary
+
+
+class TestGetCatalogsFromCdf(unittest.TestCase):
+    def setUp(self):
+        clear_catalog_cache()
+
+    def tearDown(self):
+        clear_catalog_cache()
+
+    def test_returns_empty_dict_for_missing_cdf(self):
+        with TempLibrary() as lib:
+            lib.cdf_path.unlink()  # remove the CDF
+            catalogs, _ = get_catalogs_from_cdf(str(lib.path))
+            self.assertEqual(catalogs, {})
+
+    def test_first_enum_item_is_always_unassigned(self):
+        with TempLibrary() as lib:
+            _, items = get_catalogs_from_cdf(str(lib.path))
+            self.assertEqual(items[0][0], "UNASSIGNED")
+
+    def test_parses_catalog_path_and_uuid(self):
+        u = str(uuid.uuid4())
+        with TempLibrary() as lib:
+            lib.cdf_path.write_text(f"VERSION 1\n\n{u}:Materials/Metal:Metal\n", encoding="utf-8")
+            catalogs, _ = get_catalogs_from_cdf(str(lib.path))
+            self.assertIn("Materials/Metal", catalogs)
+            self.assertEqual(catalogs["Materials/Metal"], u)
+
+    def test_parses_multiple_entries(self):
+        u1, u2 = str(uuid.uuid4()), str(uuid.uuid4())
+        with TempLibrary() as lib:
+            lib.cdf_path.write_text(
+                f"VERSION 1\n\n{u1}:Materials:Materials\n{u2}:Characters:Characters\n",
+                encoding="utf-8",
+            )
+            catalogs, _ = get_catalogs_from_cdf(str(lib.path))
+            self.assertIn("Materials", catalogs)
+            self.assertIn("Characters", catalogs)
+            self.assertEqual(len(catalogs), 2)
+
+    def test_skips_comment_lines(self):
+        u = str(uuid.uuid4())
+        with TempLibrary() as lib:
+            lib.cdf_path.write_text(
+                f"VERSION 1\n# This is a comment\n{u}:Materials:Materials\n",
+                encoding="utf-8",
+            )
+            catalogs, _ = get_catalogs_from_cdf(str(lib.path))
+            self.assertNotIn("# This is a comment", catalogs)
+            self.assertIn("Materials", catalogs)
+
+    def test_skips_version_line(self):
+        with TempLibrary() as lib:
+            lib.cdf_path.write_text("VERSION 1\n\n", encoding="utf-8")
+            catalogs, _ = get_catalogs_from_cdf(str(lib.path))
+            self.assertNotIn("VERSION 1", catalogs)
+
+    def test_skips_malformed_lines(self):
+        u = str(uuid.uuid4())
+        with TempLibrary() as lib:
+            lib.cdf_path.write_text(
+                f"VERSION 1\n\njust_a_word_with_no_colon\n{u}:Good:Good\n",
+                encoding="utf-8",
+            )
+            catalogs, _ = get_catalogs_from_cdf(str(lib.path))
+            self.assertIn("Good", catalogs)
+            self.assertNotIn("just_a_word_with_no_colon", catalogs)
+
+    def test_handles_nested_catalog_path(self):
+        u = str(uuid.uuid4())
+        with TempLibrary() as lib:
+            lib.cdf_path.write_text(
+                f"VERSION 1\n\n{u}:Characters/Heroes/Mages:Mages\n",
+                encoding="utf-8",
+            )
+            catalogs, _ = get_catalogs_from_cdf(str(lib.path))
+            self.assertIn("Characters/Heroes/Mages", catalogs)
+
+
+class TestGetCatalogPathFromUuid(unittest.TestCase):
+    def setUp(self):
+        clear_catalog_cache()
+
+    def tearDown(self):
+        clear_catalog_cache()
+
+    def test_resolves_uuid_to_path(self):
+        with TempLibrary(catalogs=["Materials/Metal"]) as lib:
+            u = lib.uuid_for("Materials/Metal")
+            result = get_catalog_path_from_uuid(str(lib.path), u)
+            self.assertEqual(result, "Materials/Metal")
+
+    def test_returns_none_for_unknown_uuid(self):
+        with TempLibrary() as lib:
+            result = get_catalog_path_from_uuid(str(lib.path), str(uuid.uuid4()))
+            self.assertIsNone(result)
+
+    def test_returns_none_for_unassigned_string(self):
+        with TempLibrary() as lib:
+            result = get_catalog_path_from_uuid(str(lib.path), "UNASSIGNED")
+            self.assertIsNone(result)
+
+    def test_returns_none_for_empty_uuid(self):
+        with TempLibrary() as lib:
+            result = get_catalog_path_from_uuid(str(lib.path), "")
+            self.assertIsNone(result)
+
+    def test_returns_none_for_invalid_uuid_format(self):
+        with TempLibrary() as lib:
+            result = get_catalog_path_from_uuid(str(lib.path), "not-a-uuid")
+            self.assertIsNone(result)
+
+    def test_returns_none_when_cdf_missing(self):
+        with TempLibrary() as lib:
+            lib.cdf_path.unlink()
+            result = get_catalog_path_from_uuid(str(lib.path), str(uuid.uuid4()))
+            self.assertIsNone(result)
+
+
+class TestCreateCatalogEntry(unittest.TestCase):
+    def setUp(self):
+        clear_catalog_cache()
+
+    def tearDown(self):
+        clear_catalog_cache()
+
+    def test_creates_entry_and_returns_valid_uuid(self):
+        with TempLibrary() as lib:
+            result = create_catalog_entry(str(lib.path), "Materials")
+            uuid.UUID(result)  # raises ValueError if invalid
+
+    def test_entry_appears_in_cdf(self):
+        with TempLibrary() as lib:
+            result_uuid = create_catalog_entry(str(lib.path), "Materials/Metal")
+            content = lib.cdf_path.read_text(encoding="utf-8")
+            self.assertIn("Materials/Metal", content)
+            self.assertIn(result_uuid, content)
+
+    def test_creates_cdf_when_missing(self):
+        with TempLibrary() as lib:
+            lib.cdf_path.unlink()
+            self.assertFalse(lib.cdf_path.exists())
+            create_catalog_entry(str(lib.path), "NewCatalog")
+            self.assertTrue(lib.cdf_path.exists())
+
+    def test_returns_same_uuid_for_duplicate_path(self):
+        with TempLibrary() as lib:
+            first = create_catalog_entry(str(lib.path), "Materials/Metal")
+            clear_catalog_cache()
+            second = create_catalog_entry(str(lib.path), "Materials/Metal")
+            self.assertEqual(first, second)
+
+    def test_preserves_existing_entries(self):
+        with TempLibrary(catalogs=["Existing"]) as lib:
+            existing_uuid = lib.uuid_for("Existing")
+            create_catalog_entry(str(lib.path), "NewCatalog")
+            content = lib.cdf_path.read_text(encoding="utf-8")
+            self.assertIn("Existing", content)
+            self.assertIn(existing_uuid, content)
+            self.assertIn("NewCatalog", content)
+
+    def test_display_name_is_last_path_component(self):
+        with TempLibrary() as lib:
+            create_catalog_entry(str(lib.path), "Characters/Heroes")
+            content = lib.cdf_path.read_text(encoding="utf-8")
+            # Line format: UUID:Characters/Heroes:Heroes
+            self.assertIn(":Heroes", content)
+
+    def test_nested_path_stored_correctly(self):
+        with TempLibrary() as lib:
+            result_uuid = create_catalog_entry(str(lib.path), "A/B/C")
+            clear_catalog_cache()
+            resolved = get_catalog_path_from_uuid(str(lib.path), result_uuid)
+            self.assertEqual(resolved, "A/B/C")
+
+    def test_multiple_distinct_catalogs(self):
+        with TempLibrary() as lib:
+            u1 = create_catalog_entry(str(lib.path), "Materials")
+            clear_catalog_cache()
+            u2 = create_catalog_entry(str(lib.path), "Characters")
+            self.assertNotEqual(u1, u2)
+            clear_catalog_cache()
+            catalogs, _ = get_catalogs_from_cdf(str(lib.path))
+            self.assertIn("Materials", catalogs)
+            self.assertIn("Characters", catalogs)

--- a/tests/test_catalog.py
+++ b/tests/test_catalog.py
@@ -1,9 +1,6 @@
 """Tests for catalog CDF read/write operations."""
 import unittest
 import uuid
-import tempfile
-import shutil
-from pathlib import Path
 from QuickAssetSaver.operators.catalog import (
     get_catalogs_from_cdf,
     get_catalog_path_from_uuid,

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,7 +1,7 @@
 """Tests for QuickAssetSaver/compatibility.py — uses mock contexts, no real Blender UI needed."""
 import unittest
-from tests.fixtures import MockContext, MockSpace, make_asset_browser_context
-from QuickAssetSaver.constants import EXCLUDED_LIBRARY_REFS, PROTECTED_LIBRARY_REFS
+from tests.fixtures import MockContext, MockSpace
+from QuickAssetSaver.constants import EXCLUDED_LIBRARY_REFS
 
 
 class TestIsAssetBrowserActive(unittest.TestCase):

--- a/tests/test_compatibility.py
+++ b/tests/test_compatibility.py
@@ -1,0 +1,125 @@
+"""Tests for QuickAssetSaver/compatibility.py — uses mock contexts, no real Blender UI needed."""
+import unittest
+from tests.fixtures import MockContext, MockSpace, make_asset_browser_context
+from QuickAssetSaver.constants import EXCLUDED_LIBRARY_REFS, PROTECTED_LIBRARY_REFS
+
+
+class TestIsAssetBrowserActive(unittest.TestCase):
+    def setUp(self):
+        from QuickAssetSaver import compatibility
+        self.fn = compatibility.is_asset_browser_active
+
+    def test_true_for_valid_asset_browser(self):
+        ctx = MockContext(MockSpace())
+        self.assertTrue(self.fn(ctx))
+
+    def test_false_when_space_data_is_none(self):
+        ctx = MockContext(None)
+        self.assertFalse(self.fn(ctx))
+
+    def test_false_for_view3d(self):
+        ctx = MockContext(MockSpace(space_type="VIEW_3D"))
+        self.assertFalse(self.fn(ctx))
+
+    def test_false_for_node_editor(self):
+        ctx = MockContext(MockSpace(space_type="NODE_EDITOR"))
+        self.assertFalse(self.fn(ctx))
+
+    def test_false_for_files_browse_mode(self):
+        ctx = MockContext(MockSpace(browse_mode="FILES"))
+        self.assertFalse(self.fn(ctx))
+
+    def test_false_for_empty_browse_mode(self):
+        ctx = MockContext(MockSpace(browse_mode=""))
+        self.assertFalse(self.fn(ctx))
+
+
+class TestIsProtectedLibrary(unittest.TestCase):
+    def setUp(self):
+        from QuickAssetSaver import compatibility
+        self.fn = compatibility.is_protected_library
+
+    def test_true_for_essentials(self):
+        ctx = MockContext(MockSpace(lib_ref="ESSENTIALS"))
+        self.assertTrue(self.fn(ctx))
+
+    def test_false_for_user_library(self):
+        ctx = MockContext(MockSpace(lib_ref="My Assets"))
+        self.assertFalse(self.fn(ctx))
+
+    def test_false_for_local(self):
+        ctx = MockContext(MockSpace(lib_ref="LOCAL"))
+        self.assertFalse(self.fn(ctx))
+
+    def test_false_for_no_params(self):
+        space = MockSpace()
+        space.params = None
+        ctx = MockContext(space)
+        self.assertFalse(self.fn(ctx))
+
+    def test_false_for_none_space(self):
+        ctx = MockContext(None)
+        self.assertFalse(self.fn(ctx))
+
+
+class TestIsUserLibrary(unittest.TestCase):
+    def setUp(self):
+        from QuickAssetSaver import compatibility
+        self.fn = compatibility.is_user_library
+
+    def test_true_for_named_library(self):
+        ctx = MockContext(MockSpace(lib_ref="My Assets"))
+        self.assertTrue(self.fn(ctx))
+
+    def test_false_for_local(self):
+        ctx = MockContext(MockSpace(lib_ref="LOCAL"))
+        self.assertFalse(self.fn(ctx))
+
+    def test_false_for_current(self):
+        ctx = MockContext(MockSpace(lib_ref="CURRENT"))
+        self.assertFalse(self.fn(ctx))
+
+    def test_false_for_all(self):
+        ctx = MockContext(MockSpace(lib_ref="ALL"))
+        self.assertFalse(self.fn(ctx))
+
+    def test_false_for_essentials(self):
+        ctx = MockContext(MockSpace(lib_ref="ESSENTIALS"))
+        self.assertFalse(self.fn(ctx))
+
+    def test_false_for_none_params(self):
+        space = MockSpace()
+        space.params = None
+        ctx = MockContext(space)
+        self.assertFalse(self.fn(ctx))
+
+    def test_all_excluded_refs_return_false(self):
+        for ref in EXCLUDED_LIBRARY_REFS:
+            ctx = MockContext(MockSpace(lib_ref=ref))
+            self.assertFalse(
+                self.fn(ctx),
+                f"is_user_library should be False for excluded ref {ref!r}"
+            )
+
+
+class TestIsOnlineLibrary(unittest.TestCase):
+    def setUp(self):
+        from QuickAssetSaver import compatibility
+        self.fn = compatibility.is_online_library
+
+    def test_false_when_no_type_attr(self):
+        # No asset_library_type attribute → default False (safe)
+        ctx = MockContext(MockSpace(lib_ref="My Library"))
+        self.assertFalse(self.fn(ctx))
+
+    def test_false_for_custom_type(self):
+        from tests.fixtures import MockParams
+        space = MockSpace()
+        space.params = MockParams("My Library")
+        space.params.asset_library_type = "CUSTOM"
+        ctx = MockContext(space)
+        self.assertFalse(self.fn(ctx))
+
+    def test_false_for_none_space(self):
+        ctx = MockContext(None)
+        self.assertFalse(self.fn(ctx))

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -1,0 +1,108 @@
+"""Tests for QuickAssetSaver/constants.py"""
+import unittest
+from QuickAssetSaver.constants import (
+    VIRTUAL_LIBRARY_REFS,
+    PROTECTED_LIBRARY_REFS,
+    EXCLUDED_LIBRARY_REFS,
+    COMPANION_FOLDER_GROUPS,
+    COMPANION_FOLDER_NAMES,
+    THUMBNAIL_EXTENSIONS,
+    METADATA_EXTENSIONS,
+    MIN_BLEND_FILE_SIZE,
+    MAX_INCREMENTAL_FILES,
+    LARGE_SELECTION_WARNING_THRESHOLD,
+    DEFAULT_MAX_BUNDLE_SIZE_MB,
+    LARGE_BUNDLE_WARNING_MB,
+)
+
+
+class TestLibraryRefSets(unittest.TestCase):
+    def test_virtual_refs_is_frozenset(self):
+        self.assertIsInstance(VIRTUAL_LIBRARY_REFS, frozenset)
+
+    def test_protected_refs_is_frozenset(self):
+        self.assertIsInstance(PROTECTED_LIBRARY_REFS, frozenset)
+
+    def test_excluded_refs_is_frozenset(self):
+        self.assertIsInstance(EXCLUDED_LIBRARY_REFS, frozenset)
+
+    def test_local_in_virtual(self):
+        self.assertIn("LOCAL", VIRTUAL_LIBRARY_REFS)
+
+    def test_current_in_virtual(self):
+        self.assertIn("CURRENT", VIRTUAL_LIBRARY_REFS)
+
+    def test_all_in_virtual(self):
+        self.assertIn("ALL", VIRTUAL_LIBRARY_REFS)
+
+    def test_essentials_in_protected(self):
+        self.assertIn("ESSENTIALS", PROTECTED_LIBRARY_REFS)
+
+    def test_essentials_not_in_virtual(self):
+        self.assertNotIn("ESSENTIALS", VIRTUAL_LIBRARY_REFS)
+
+    def test_excluded_is_union_of_virtual_and_protected(self):
+        self.assertEqual(EXCLUDED_LIBRARY_REFS, VIRTUAL_LIBRARY_REFS | PROTECTED_LIBRARY_REFS)
+
+    def test_virtual_refs_subset_of_excluded(self):
+        self.assertTrue(VIRTUAL_LIBRARY_REFS.issubset(EXCLUDED_LIBRARY_REFS))
+
+    def test_protected_refs_subset_of_excluded(self):
+        self.assertTrue(PROTECTED_LIBRARY_REFS.issubset(EXCLUDED_LIBRARY_REFS))
+
+
+class TestCompanionFolders(unittest.TestCase):
+    def test_companion_folder_groups_is_list(self):
+        self.assertIsInstance(COMPANION_FOLDER_GROUPS, list)
+
+    def test_companion_folder_names_is_list(self):
+        self.assertIsInstance(COMPANION_FOLDER_NAMES, list)
+
+    def test_companion_folder_names_flat(self):
+        # Names list should be flat strings, not nested lists
+        for name in COMPANION_FOLDER_NAMES:
+            self.assertIsInstance(name, str)
+
+    def test_textures_variants_present(self):
+        self.assertIn("textures", COMPANION_FOLDER_NAMES)
+        self.assertIn("Textures", COMPANION_FOLDER_NAMES)
+
+    def test_companion_names_matches_flattened_groups(self):
+        expected = [name for group in COMPANION_FOLDER_GROUPS for name in group]
+        self.assertEqual(COMPANION_FOLDER_NAMES, expected)
+
+
+class TestFileExtensions(unittest.TestCase):
+    def test_thumbnail_extensions_all_start_with_dot(self):
+        for ext in THUMBNAIL_EXTENSIONS:
+            self.assertTrue(ext.startswith("."), f"{ext!r} should start with '.'")
+
+    def test_metadata_extensions_all_start_with_dot(self):
+        for ext in METADATA_EXTENSIONS:
+            self.assertTrue(ext.startswith("."), f"{ext!r} should start with '.'")
+
+    def test_png_in_thumbnails(self):
+        self.assertIn(".png", THUMBNAIL_EXTENSIONS)
+
+    def test_json_in_metadata(self):
+        self.assertIn(".json", METADATA_EXTENSIONS)
+
+
+class TestNumerics(unittest.TestCase):
+    def test_min_blend_file_size_positive(self):
+        self.assertGreater(MIN_BLEND_FILE_SIZE, 0)
+
+    def test_max_incremental_files_large(self):
+        self.assertGreaterEqual(MAX_INCREMENTAL_FILES, 999)
+
+    def test_large_selection_threshold_positive(self):
+        self.assertGreater(LARGE_SELECTION_WARNING_THRESHOLD, 0)
+
+    def test_default_bundle_size_at_least_512mb(self):
+        self.assertGreaterEqual(DEFAULT_MAX_BUNDLE_SIZE_MB, 512)
+
+    def test_large_bundle_warning_less_than_default(self):
+        self.assertLess(LARGE_BUNDLE_WARNING_MB, DEFAULT_MAX_BUNDLE_SIZE_MB)
+
+    def test_large_bundle_warning_is_75_percent(self):
+        self.assertEqual(LARGE_BUNDLE_WARNING_MB, int(DEFAULT_MAX_BUNDLE_SIZE_MB * 0.75))

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -1,0 +1,160 @@
+"""
+Tests that the addon registers cleanly and all expected types/operators exist.
+These run after the addon is registered by blender_test_runner.py.
+"""
+import unittest
+import bpy
+from QuickAssetSaver.properties import get_addon_preferences
+
+
+class TestWindowManagerProps(unittest.TestCase):
+    """All four PropertyGroups must be attached to WindowManager after registration."""
+
+    def test_qam_save_props_exists(self):
+        self.assertTrue(hasattr(bpy.types.WindowManager, "qam_save_props"))
+
+    def test_qam_bundler_props_exists(self):
+        self.assertTrue(hasattr(bpy.types.WindowManager, "qam_bundler_props"))
+
+    def test_qam_manage_props_exists(self):
+        self.assertTrue(hasattr(bpy.types.WindowManager, "qam_manage_props"))
+
+    def test_qam_metadata_edit_exists(self):
+        self.assertTrue(hasattr(bpy.types.WindowManager, "qam_metadata_edit"))
+
+    def test_save_props_accessible_on_wm_instance(self):
+        wm = bpy.context.window_manager
+        props = wm.qam_save_props
+        self.assertIsNotNone(props)
+
+    def test_bundler_props_accessible_on_wm_instance(self):
+        wm = bpy.context.window_manager
+        self.assertIsNotNone(wm.qam_bundler_props)
+
+    def test_manage_props_accessible_on_wm_instance(self):
+        wm = bpy.context.window_manager
+        self.assertIsNotNone(wm.qam_manage_props)
+
+    def test_metadata_edit_accessible_on_wm_instance(self):
+        wm = bpy.context.window_manager
+        self.assertIsNotNone(wm.qam_metadata_edit)
+
+
+class TestSavePropsFields(unittest.TestCase):
+    """Save PropertyGroup must expose the fields the panel and operator use."""
+
+    def setUp(self):
+        self.props = bpy.context.window_manager.qam_save_props
+
+    def test_has_selected_library(self):
+        self.assertTrue(hasattr(self.props, "selected_library"))
+
+    def test_has_catalog(self):
+        self.assertTrue(hasattr(self.props, "catalog"))
+
+    def test_has_auto_create_catalog(self):
+        self.assertTrue(hasattr(self.props, "auto_create_catalog"))
+
+    def test_auto_create_catalog_default_false(self):
+        self.assertFalse(self.props.auto_create_catalog)
+
+    def test_has_asset_display_name(self):
+        self.assertTrue(hasattr(self.props, "asset_display_name"))
+
+    def test_has_asset_file_name(self):
+        self.assertTrue(hasattr(self.props, "asset_file_name"))
+
+    def test_has_conflict_resolution(self):
+        self.assertTrue(hasattr(self.props, "conflict_resolution"))
+
+    def test_conflict_resolution_default_increment(self):
+        self.assertEqual(self.props.conflict_resolution, "INCREMENT")
+
+    def test_has_show_success_message(self):
+        self.assertTrue(hasattr(self.props, "show_success_message"))
+
+    def test_has_metadata_fields(self):
+        for field in ("asset_description", "asset_author", "asset_license", "asset_copyright"):
+            with self.subTest(field=field):
+                self.assertTrue(hasattr(self.props, field))
+
+
+class TestBundlerPropsFields(unittest.TestCase):
+    def setUp(self):
+        self.props = bpy.context.window_manager.qam_bundler_props
+
+    def test_has_output_name(self):
+        self.assertTrue(hasattr(self.props, "output_name"))
+
+    def test_output_name_default_nonempty(self):
+        self.assertTrue(self.props.output_name)
+
+    def test_has_save_path(self):
+        self.assertTrue(hasattr(self.props, "save_path"))
+
+    def test_has_duplicate_mode(self):
+        self.assertTrue(hasattr(self.props, "duplicate_mode"))
+
+    def test_has_copy_catalog(self):
+        self.assertTrue(hasattr(self.props, "copy_catalog"))
+
+
+class TestManagePropsFields(unittest.TestCase):
+    def setUp(self):
+        self.props = bpy.context.window_manager.qam_manage_props
+
+    def test_has_move_target_library(self):
+        self.assertTrue(hasattr(self.props, "move_target_library"))
+
+    def test_has_move_target_catalog(self):
+        self.assertTrue(hasattr(self.props, "move_target_catalog"))
+
+    def test_has_move_conflict_resolution(self):
+        self.assertTrue(hasattr(self.props, "move_conflict_resolution"))
+
+
+class TestMetadataEditFields(unittest.TestCase):
+    def setUp(self):
+        self.props = bpy.context.window_manager.qam_metadata_edit
+
+    def test_has_edit_name(self):
+        self.assertTrue(hasattr(self.props, "edit_name"))
+
+    def test_has_edit_tags(self):
+        self.assertTrue(hasattr(self.props, "edit_tags"))
+
+    def test_has_source_file(self):
+        self.assertTrue(hasattr(self.props, "source_file"))
+
+    def test_has_changes_method(self):
+        self.assertTrue(callable(getattr(self.props, "has_changes", None)))
+
+    def test_has_changes_false_when_synced(self):
+        # orig_* and edit_* are equal by default → no changes
+        self.assertFalse(self.props.has_changes())
+
+
+class TestOperatorsRegistered(unittest.TestCase):
+    EXPECTED_OPS = [
+        ("qam", "save_asset_to_library_direct"),
+        ("qam", "open_library_folder"),
+        ("qam", "bundle_assets"),
+        ("qam", "open_bundle_folder"),
+        ("qam", "move_selected_to_library"),
+        ("qam", "delete_selected_assets"),
+        ("qam", "swap_selected_with_asset"),
+        ("qam", "apply_metadata_changes"),
+        ("qam", "toggle_edit_mode"),
+        ("qam", "tag_add"),
+        ("qam", "tag_remove"),
+    ]
+
+    def test_all_operators_registered(self):
+        for module, name in self.EXPECTED_OPS:
+            with self.subTest(op=f"{module}.{name}"):
+                mod = getattr(bpy.ops, module, None)
+                self.assertIsNotNone(mod, f"bpy.ops.{module} not found")
+                self.assertTrue(
+                    hasattr(mod, name),
+                    f"Operator {module}.{name} not registered"
+                )

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -4,7 +4,6 @@ These run after the addon is registered by blender_test_runner.py.
 """
 import unittest
 import bpy
-from QuickAssetSaver.properties import get_addon_preferences
 
 
 class TestWindowManagerProps(unittest.TestCase):

--- a/tests/test_registration.py
+++ b/tests/test_registration.py
@@ -63,12 +63,6 @@ class TestSavePropsFields(unittest.TestCase):
     def test_has_asset_file_name(self):
         self.assertTrue(hasattr(self.props, "asset_file_name"))
 
-    def test_has_conflict_resolution(self):
-        self.assertTrue(hasattr(self.props, "conflict_resolution"))
-
-    def test_conflict_resolution_default_increment(self):
-        self.assertEqual(self.props.conflict_resolution, "INCREMENT")
-
     def test_has_show_success_message(self):
         self.assertTrue(hasattr(self.props, "show_success_message"))
 

--- a/tests/test_save_catalog.py
+++ b/tests/test_save_catalog.py
@@ -5,17 +5,11 @@ Tests for catalog-related save operator behaviour:
 """
 import unittest
 import uuid
-import tempfile
-from pathlib import Path
 
 import bpy
 
 from QuickAssetSaver.operators.save import _auto_create_catalog_if_needed
-from QuickAssetSaver.operators.catalog import (
-    get_catalog_path_from_uuid,
-    create_catalog_entry,
-    clear_catalog_cache,
-)
+from QuickAssetSaver.operators.catalog import clear_catalog_cache
 from QuickAssetSaver.operators.file_io import write_blend_file
 from tests.fixtures import TempLibrary, make_test_asset, remove_test_asset
 
@@ -120,18 +114,12 @@ class TestAutoCreateCatalog(unittest.TestCase):
         """If the catalog path already exists in the target, return its UUID."""
         with TempLibrary(catalogs=["Characters"]) as target:
             target_uuid = target.uuid_for("Characters")
-            # Use a different source UUID for the same path
-            source_uuid = str(uuid.uuid4())
-            source_cdf_content = (
-                f"VERSION 1\n\n{source_uuid}:Characters:Characters\n"
-            )
             # Write the source CDF directly into the target dir temporarily
             # to simulate both sides having "Characters" with different UUIDs
             with TempLibrary(catalogs=["Characters"]) as source:
                 clear_catalog_cache()
-                # Call with source UUID that maps to "Characters" in the source
-                source_u = source.uuid_for("Characters")
                 # The target already has "Characters" under target_uuid.
+                _ = source  # source fixture kept alive for the duration of the call
                 # clear cache so target CDF is re-read
                 clear_catalog_cache()
                 result = _auto_create_catalog_if_needed(str(target.path), target_uuid)

--- a/tests/test_save_catalog.py
+++ b/tests/test_save_catalog.py
@@ -1,0 +1,146 @@
+"""
+Tests for catalog-related save operator behaviour:
+  - Bug #9: source asset catalog must not be modified after save
+  - Auto-create catalog: _auto_create_catalog_if_needed
+"""
+import unittest
+import uuid
+import tempfile
+from pathlib import Path
+
+import bpy
+
+from QuickAssetSaver.operators.save import _auto_create_catalog_if_needed
+from QuickAssetSaver.operators.catalog import (
+    get_catalog_path_from_uuid,
+    create_catalog_entry,
+    clear_catalog_cache,
+)
+from QuickAssetSaver.operators.file_io import write_blend_file
+from tests.fixtures import TempLibrary, make_test_asset, remove_test_asset
+
+
+class TestCatalogPreservation(unittest.TestCase):
+    """
+    Regression tests for Bug #9.
+    The source asset's catalog_id must survive write_blend_file unchanged.
+    This mirrors the capture/restore pattern added to the save operator.
+    """
+
+    def setUp(self):
+        self.obj = make_test_asset(name="QAM_Bug9_Test")
+        self.original_uuid = str(uuid.uuid4())
+        self.obj.asset_data.catalog_id = self.original_uuid
+
+    def tearDown(self):
+        remove_test_asset(self.obj)
+        clear_catalog_cache()
+
+    def test_write_blend_does_not_alter_source_catalog(self):
+        """write_blend_file itself must not change the source datablock."""
+        with TempLibrary() as lib:
+            out = lib.path / "asset.blend"
+            write_blend_file(out, {self.obj})
+            # Source catalog must be unchanged
+            self.assertEqual(self.obj.asset_data.catalog_id, self.original_uuid)
+
+    def test_capture_and_restore_pattern(self):
+        """Capture → modify → write → restore preserves the original UUID."""
+        with TempLibrary() as lib:
+            other_uuid = str(uuid.uuid4())
+
+            # Capture
+            captured = self.obj.asset_data.catalog_id
+
+            # Modify (as the save operator does)
+            self.obj.asset_data.catalog_id = other_uuid
+
+            # Write
+            out = lib.path / "asset.blend"
+            write_blend_file(out, {self.obj})
+
+            # Restore
+            self.obj.asset_data.catalog_id = captured
+
+            # Source must have the original UUID back
+            self.assertEqual(self.obj.asset_data.catalog_id, self.original_uuid)
+
+    def test_catalog_in_written_file_is_modified_uuid(self):
+        """The written .blend file should contain the modified UUID, not the original."""
+        with TempLibrary() as lib:
+            other_uuid = str(uuid.uuid4())
+
+            captured = self.obj.asset_data.catalog_id
+            self.obj.asset_data.catalog_id = other_uuid
+            out = lib.path / "asset.blend"
+            write_blend_file(out, {self.obj})
+            self.obj.asset_data.catalog_id = captured
+
+            # Verify the written file contains the OTHER uuid
+            loaded = []
+            with bpy.data.libraries.load(str(out), link=False, assets_only=True) as (src, dst):
+                if src.objects:
+                    dst.objects = list(src.objects)
+            for o in bpy.data.objects:
+                if o.name == "QAM_Bug9_Test" and o is not self.obj and o.asset_data:
+                    self.assertEqual(o.asset_data.catalog_id, other_uuid)
+                    loaded.append(o)
+            for o in loaded:
+                remove_test_asset(o)
+
+
+class TestAutoCreateCatalog(unittest.TestCase):
+    """Tests for _auto_create_catalog_if_needed in operators/save.py."""
+
+    def setUp(self):
+        clear_catalog_cache()
+
+    def tearDown(self):
+        clear_catalog_cache()
+
+    def test_returns_none_for_unresolvable_uuid(self):
+        """If the UUID can't be resolved to a path, return None."""
+        with TempLibrary() as target:
+            result = _auto_create_catalog_if_needed(str(target.path), str(uuid.uuid4()))
+            self.assertIsNone(result)
+
+    def test_creates_catalog_from_target_fallback(self):
+        """
+        When no source CDF is available (bpy.data.filepath empty in background mode),
+        _auto_create_catalog_if_needed falls back to the target library CDF.
+        A UUID that already exists there should be returned unchanged.
+        """
+        with TempLibrary(catalogs=["Materials/Metal"]) as target:
+            existing_uuid = target.uuid_for("Materials/Metal")
+            clear_catalog_cache()
+            result = _auto_create_catalog_if_needed(str(target.path), existing_uuid)
+            self.assertEqual(result, existing_uuid)
+
+    def test_returns_existing_uuid_when_path_in_target(self):
+        """If the catalog path already exists in the target, return its UUID."""
+        with TempLibrary(catalogs=["Characters"]) as target:
+            target_uuid = target.uuid_for("Characters")
+            # Use a different source UUID for the same path
+            source_uuid = str(uuid.uuid4())
+            source_cdf_content = (
+                f"VERSION 1\n\n{source_uuid}:Characters:Characters\n"
+            )
+            # Write the source CDF directly into the target dir temporarily
+            # to simulate both sides having "Characters" with different UUIDs
+            with TempLibrary(catalogs=["Characters"]) as source:
+                clear_catalog_cache()
+                # Call with source UUID that maps to "Characters" in the source
+                source_u = source.uuid_for("Characters")
+                # The target already has "Characters" under target_uuid.
+                # clear cache so target CDF is re-read
+                clear_catalog_cache()
+                result = _auto_create_catalog_if_needed(str(target.path), target_uuid)
+            self.assertEqual(result, target_uuid)
+
+    def test_does_not_create_entry_for_none_uuid(self):
+        """An unresolvable UUID must not create any new entries in the target CDF."""
+        with TempLibrary() as target:
+            content_before = target.cdf_path.read_text(encoding="utf-8")
+            _auto_create_catalog_if_needed(str(target.path), str(uuid.uuid4()))
+            content_after = target.cdf_path.read_text(encoding="utf-8")
+            self.assertEqual(content_before, content_after)

--- a/tests/test_send2trash.py
+++ b/tests/test_send2trash.py
@@ -1,0 +1,158 @@
+"""
+Tests for the Send2Trash fallback safety guarantee.
+
+The core invariant: if Send2Trash is unavailable the addon must NEVER
+permanently delete a file via os.remove or any other means. It must
+raise RuntimeError with a message that tells the user where the file is.
+
+We test this in three layers:
+  1. The fallback function itself — raises, doesn't delete
+  2. The real move_to_trash is callable from both delete and move modules
+  3. When Send2Trash IS available it successfully moves a real file
+"""
+
+import tempfile
+import unittest
+from pathlib import Path
+
+
+# ── Helpers ───────────────────────────────────────────────────────────────────
+
+def _make_fallback():
+    """
+    Construct the fallback move_to_trash exactly as it is defined in the
+    addon, so the test is independent of whether send2trash is installed.
+    """
+    def move_to_trash(path) -> None:
+        p = Path(path)
+        raise RuntimeError(
+            f"Send2Trash is unavailable. '{p.name}' was NOT deleted.\n"
+            f"You can delete it manually at: {p.parent}"
+        )
+    return move_to_trash
+
+
+# ── Tests ─────────────────────────────────────────────────────────────────────
+
+class TestFallbackBehavior(unittest.TestCase):
+    """
+    The fallback function (no Send2Trash installed) must raise RuntimeError
+    and leave the file intact. This is the critical safety guarantee — we
+    must never silently call os.remove() as a "fallback to trash".
+    """
+
+    def setUp(self):
+        self.fallback = _make_fallback()
+        self._tmpdir = tempfile.mkdtemp(prefix="qam_trash_test_")
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_fallback_raises_runtime_error(self):
+        test_file = Path(self._tmpdir) / "my_asset.blend"
+        test_file.touch()
+        with self.assertRaises(RuntimeError):
+            self.fallback(str(test_file))
+
+    def test_fallback_file_still_exists_after_raise(self):
+        """The file must survive the fallback — it was NOT deleted."""
+        test_file = Path(self._tmpdir) / "survivor.blend"
+        test_file.touch()
+        try:
+            self.fallback(str(test_file))
+        except RuntimeError:
+            pass
+        self.assertTrue(test_file.exists(), "File was deleted by the fallback — critical safety violation")
+
+    def test_fallback_error_message_contains_filename(self):
+        test_file = Path(self._tmpdir) / "important_asset.blend"
+        test_file.touch()
+        with self.assertRaises(RuntimeError) as ctx:
+            self.fallback(str(test_file))
+        self.assertIn("important_asset.blend", str(ctx.exception))
+
+    def test_fallback_error_message_contains_parent_directory(self):
+        """User must be told WHERE the file is so they can delete it themselves."""
+        test_file = Path(self._tmpdir) / "asset.blend"
+        test_file.touch()
+        with self.assertRaises(RuntimeError) as ctx:
+            self.fallback(str(test_file))
+        self.assertIn(self._tmpdir, str(ctx.exception))
+
+    def test_fallback_error_message_says_not_deleted(self):
+        test_file = Path(self._tmpdir) / "asset.blend"
+        test_file.touch()
+        with self.assertRaises(RuntimeError) as ctx:
+            self.fallback(str(test_file))
+        self.assertIn("NOT deleted", str(ctx.exception))
+
+
+class TestMoveToTrashImportable(unittest.TestCase):
+    """move_to_trash must be a callable defined at module level in both operators."""
+
+    def test_delete_module_has_move_to_trash(self):
+        from QuickAssetSaver.operators.delete import move_to_trash
+        self.assertTrue(callable(move_to_trash))
+
+    def test_move_module_has_move_to_trash(self):
+        from QuickAssetSaver.operators.move import move_to_trash
+        self.assertTrue(callable(move_to_trash))
+
+    def test_both_modules_define_independently(self):
+        """Each module defines its own move_to_trash — they should not be the same object."""
+        from QuickAssetSaver.operators.delete import move_to_trash as dt
+        from QuickAssetSaver.operators.move import move_to_trash as mt
+        # Both callable; whether same or different objects is an implementation detail
+        self.assertTrue(callable(dt))
+        self.assertTrue(callable(mt))
+
+
+class TestMoveToTrashRealBehavior(unittest.TestCase):
+    """
+    When Send2Trash IS available (wheels/Send2Trash-*.whl is installed),
+    move_to_trash should successfully trash the file.
+    When it is NOT available, it must raise RuntimeError — never silently delete.
+    """
+
+    def setUp(self):
+        self._tmpdir = tempfile.mkdtemp(prefix="qam_real_trash_")
+
+    def tearDown(self):
+        import shutil
+        shutil.rmtree(self._tmpdir, ignore_errors=True)
+
+    def test_real_move_to_trash_does_not_permanently_delete(self):
+        """
+        Whatever happens — Send2Trash available or not — os.remove must never
+        be the outcome. Either the file is trashed (acceptable) or RuntimeError
+        is raised with a helpful message (acceptable). A silent permanent
+        deletion is never acceptable.
+
+        We verify this by checking: if an exception IS raised, it must be a
+        RuntimeError with our expected message, not an OS-level deletion error.
+        """
+        from QuickAssetSaver.operators.delete import move_to_trash
+
+        test_file = Path(self._tmpdir) / "qam_real_trash_test.blend"
+        test_file.touch()
+
+        try:
+            move_to_trash(str(test_file))
+            # Send2Trash trashed the file — success, no assertion needed
+        except RuntimeError as e:
+            # Fallback raised — that is acceptable
+            self.assertIn("NOT deleted", str(e),
+                "RuntimeError from fallback must contain 'NOT deleted'")
+            # File must still exist when fallback raises
+            self.assertTrue(test_file.exists(),
+                "Fallback raised RuntimeError but file was deleted — safety violation")
+        except Exception as e:
+            self.fail(f"move_to_trash raised an unexpected exception type: {type(e).__name__}: {e}")
+
+    def test_nonexistent_file_raises_exception(self):
+        """Calling move_to_trash on a nonexistent path must raise, not silently succeed."""
+        from QuickAssetSaver.operators.delete import move_to_trash
+        bad_path = str(Path(self._tmpdir) / "does_not_exist.blend")
+        with self.assertRaises(Exception):
+            move_to_trash(bad_path)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -96,7 +96,6 @@ class TestBuildAssetFilename(unittest.TestCase):
         self.assertIn("S", result)
 
     def test_date_appended(self):
-        import re
         result = build_asset_filename("Asset", self._make_prefs(date=True))
         self.assertRegex(result, r"\d{4}-\d{2}-\d{2}")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,0 +1,149 @@
+"""Tests for QuickAssetSaver/operators/utils.py"""
+import unittest
+import tempfile
+from pathlib import Path
+from QuickAssetSaver.operators.utils import (
+    sanitize_name,
+    build_asset_filename,
+    increment_filename,
+)
+from tests.fixtures import MockPrefs
+
+
+class TestSanitizeName(unittest.TestCase):
+    def test_plain_name_unchanged(self):
+        self.assertEqual(sanitize_name("MyAsset"), "MyAsset")
+
+    def test_forward_slash_replaced(self):
+        result = sanitize_name("Materials/Metal")
+        self.assertNotIn("/", result)
+
+    def test_backslash_replaced(self):
+        result = sanitize_name("Assets\\Metal")
+        self.assertNotIn("\\", result)
+
+    def test_windows_invalid_chars_replaced(self):
+        for ch in '<>:"|?*':
+            result = sanitize_name(f"file{ch}name")
+            self.assertNotIn(ch, result, f"char {ch!r} should be replaced")
+
+    def test_path_traversal_blocked(self):
+        result = sanitize_name("../../etc/passwd")
+        self.assertNotIn("/", result)
+        self.assertNotIn("..", result.split("_")[0])  # leading traversal gone
+
+    def test_empty_string_returns_asset(self):
+        self.assertEqual(sanitize_name(""), "asset")
+
+    def test_none_returns_asset(self):
+        self.assertEqual(sanitize_name(None), "asset")
+
+    def test_non_string_returns_asset(self):
+        self.assertEqual(sanitize_name(42), "asset")
+
+    def test_respects_max_length(self):
+        long_name = "a" * 300
+        self.assertLessEqual(len(sanitize_name(long_name)), 128)
+
+    def test_custom_max_length(self):
+        result = sanitize_name("a" * 200, max_length=64)
+        self.assertLessEqual(len(result), 64)
+
+    def test_strips_leading_spaces(self):
+        result = sanitize_name("  asset")
+        self.assertFalse(result.startswith(" "))
+
+    def test_strips_trailing_dots(self):
+        result = sanitize_name("asset...")
+        self.assertFalse(result.endswith("."))
+
+    def test_unicode_passthrough(self):
+        # Unicode letters are valid — should not be stripped
+        result = sanitize_name("Matériaux")
+        self.assertIn("Mat", result)
+
+    def test_only_invalid_chars_returns_asset(self):
+        result = sanitize_name(".....")
+        self.assertEqual(result, "asset")
+
+
+class TestBuildAssetFilename(unittest.TestCase):
+    def _make_prefs(self, prefix="", suffix="", date=False):
+        p = MockPrefs()
+        p.filename_prefix = prefix
+        p.filename_suffix = suffix
+        p.include_date_in_filename = date
+        return p
+
+    def test_no_affixes(self):
+        result = build_asset_filename("MyAsset", self._make_prefs())
+        self.assertEqual(result, "MyAsset")
+
+    def test_with_prefix(self):
+        result = build_asset_filename("MyAsset", self._make_prefs(prefix="LIB"))
+        self.assertTrue(result.startswith("LIB"))
+        self.assertIn("MyAsset", result)
+
+    def test_with_suffix(self):
+        result = build_asset_filename("MyAsset", self._make_prefs(suffix="v1"))
+        self.assertTrue(result.endswith("v1"))
+        self.assertIn("MyAsset", result)
+
+    def test_with_prefix_and_suffix(self):
+        result = build_asset_filename("Asset", self._make_prefs(prefix="P", suffix="S"))
+        self.assertIn("Asset", result)
+        self.assertIn("P", result)
+        self.assertIn("S", result)
+
+    def test_date_appended(self):
+        import re
+        result = build_asset_filename("Asset", self._make_prefs(date=True))
+        self.assertRegex(result, r"\d{4}-\d{2}-\d{2}")
+
+    def test_empty_prefix_ignored(self):
+        result = build_asset_filename("Asset", self._make_prefs(prefix=""))
+        self.assertFalse(result.startswith("_"))
+
+    def test_returns_string(self):
+        result = build_asset_filename("Asset", self._make_prefs())
+        self.assertIsInstance(result, str)
+
+
+class TestIncrementFilename(unittest.TestCase):
+    def test_no_conflict_returns_base(self):
+        with tempfile.TemporaryDirectory() as d:
+            result = increment_filename(Path(d), "asset", ".blend")
+            self.assertEqual(result.name, "asset.blend")
+
+    def test_conflict_increments_to_001(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d)
+            (p / "asset.blend").touch()
+            result = increment_filename(p, "asset", ".blend")
+            self.assertEqual(result.name, "asset_001.blend")
+
+    def test_multiple_conflicts_increment_sequentially(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d)
+            (p / "asset.blend").touch()
+            (p / "asset_001.blend").touch()
+            (p / "asset_002.blend").touch()
+            result = increment_filename(p, "asset", ".blend")
+            self.assertEqual(result.name, "asset_003.blend")
+
+    def test_returns_path_object(self):
+        with tempfile.TemporaryDirectory() as d:
+            result = increment_filename(Path(d), "asset", ".blend")
+            self.assertIsInstance(result, Path)
+
+    def test_result_is_inside_base_path(self):
+        with tempfile.TemporaryDirectory() as d:
+            p = Path(d)
+            result = increment_filename(p, "asset", ".blend")
+            self.assertEqual(result.parent.resolve(), p.resolve())
+
+    def test_handles_string_base_path(self):
+        with tempfile.TemporaryDirectory() as d:
+            # Should accept string paths too
+            result = increment_filename(d, "asset", ".blend")
+            self.assertIsInstance(result, Path)

--- a/tests/test_write_blend.py
+++ b/tests/test_write_blend.py
@@ -1,0 +1,130 @@
+"""
+Integration tests for write_blend_file and count_assets_in_blend.
+Creates real Blender datablocks, writes them, and verifies the output.
+"""
+import unittest
+import tempfile
+from pathlib import Path
+import bpy
+from QuickAssetSaver.operators.file_io import write_blend_file, count_assets_in_blend
+from tests.fixtures import make_test_asset, remove_test_asset
+
+
+class TestWriteBlendFile(unittest.TestCase):
+    def setUp(self):
+        self.obj = make_test_asset(
+            name="QAM_WriteTest",
+            description="Test description",
+            author="Test Author",
+        )
+
+    def tearDown(self):
+        remove_test_asset(self.obj)
+
+    def test_returns_true_on_success(self):
+        with tempfile.TemporaryDirectory() as d:
+            result = write_blend_file(Path(d) / "out.blend", {self.obj})
+            self.assertTrue(result)
+
+    def test_creates_file(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d) / "out.blend"
+            write_blend_file(out, {self.obj})
+            self.assertTrue(out.exists())
+
+    def test_file_is_not_empty(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d) / "out.blend"
+            write_blend_file(out, {self.obj})
+            self.assertGreater(out.stat().st_size, 100)
+
+    def test_returns_false_for_unwritable_path(self):
+        bad = Path("/nonexistent_qam_test_dir/out.blend")
+        result = write_blend_file(bad, {self.obj})
+        self.assertFalse(result)
+
+    def test_written_file_contains_asset(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d) / "out.blend"
+            write_blend_file(out, {self.obj})
+            info = count_assets_in_blend(out)
+            self.assertGreater(info["count"], 0)
+            names = [a["name"] for a in info["assets"]]
+            self.assertIn("QAM_WriteTest", names)
+
+    def test_write_multiple_datablocks(self):
+        obj2 = make_test_asset(name="QAM_WriteTest2")
+        try:
+            with tempfile.TemporaryDirectory() as d:
+                out = Path(d) / "out.blend"
+                write_blend_file(out, {self.obj, obj2})
+                info = count_assets_in_blend(out)
+                self.assertGreaterEqual(info["count"], 2)
+        finally:
+            remove_test_asset(obj2)
+
+
+class TestWriteBlendPreservesMetadata(unittest.TestCase):
+    """Metadata written to the .blend file must survive a round-trip load."""
+
+    def setUp(self):
+        self.obj = make_test_asset(
+            name="QAM_MetaTest",
+            description="A test description",
+            author="Test Author",
+        )
+        self.obj.asset_data.license = "CC0"
+        self.obj.asset_data.copyright = "2026 Test"
+
+    def tearDown(self):
+        remove_test_asset(self.obj)
+        # Clean up anything that was loaded during the test
+        for obj in list(bpy.data.objects):
+            if obj.name.startswith("QAM_MetaTest") and obj != self.obj:
+                remove_test_asset(obj)
+
+    def test_description_survives_round_trip(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d) / "meta.blend"
+            write_blend_file(out, {self.obj})
+
+            loaded = []
+            with bpy.data.libraries.load(str(out), link=False, assets_only=True) as (src, dst):
+                if src.objects:
+                    dst.objects = list(src.objects)
+
+            for obj in bpy.data.objects:
+                if obj.name == "QAM_MetaTest" and obj.asset_data and obj is not self.obj:
+                    self.assertEqual(obj.asset_data.description, "A test description")
+                    self.assertEqual(obj.asset_data.author, "Test Author")
+                    loaded.append(obj)
+
+            for obj in loaded:
+                remove_test_asset(obj)
+
+
+class TestCountAssetsInBlend(unittest.TestCase):
+    def setUp(self):
+        self.obj = make_test_asset(name="QAM_CountTest")
+
+    def tearDown(self):
+        remove_test_asset(self.obj)
+
+    def test_returns_count_dict_structure(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d) / "count.blend"
+            write_blend_file(out, {self.obj})
+            result = count_assets_in_blend(out)
+            self.assertIn("count", result)
+            self.assertIn("assets", result)
+
+    def test_count_matches_assets_list_length(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d) / "count.blend"
+            write_blend_file(out, {self.obj})
+            result = count_assets_in_blend(out)
+            self.assertEqual(result["count"], len(result["assets"]))
+
+    def test_returns_zero_for_nonexistent_file(self):
+        result = count_assets_in_blend(Path("/nonexistent/file.blend"))
+        self.assertEqual(result["count"], 0)

--- a/tests/test_write_blend.py
+++ b/tests/test_write_blend.py
@@ -7,7 +7,7 @@ import tempfile
 from pathlib import Path
 import bpy
 from QuickAssetSaver.operators.file_io import write_blend_file, count_assets_in_blend
-from tests.fixtures import make_test_asset, remove_test_asset
+from tests.fixtures import make_test_asset, remove_test_asset, make_compositor_asset, remove_compositor_asset
 
 
 class TestWriteBlendFile(unittest.TestCase):
@@ -128,3 +128,133 @@ class TestCountAssetsInBlend(unittest.TestCase):
     def test_returns_zero_for_nonexistent_file(self):
         result = count_assets_in_blend(Path("/nonexistent/file.blend"))
         self.assertEqual(result["count"], 0)
+
+
+class TestWriteBlendCompositorAssets(unittest.TestCase):
+    """Regression test for issue #14: a compositor node group asset with a
+    Render Layer node must not pull its referenced Scene (and everything the
+    scene contains) into the written asset file."""
+
+    def setUp(self):
+        self.node_tree, self.scene, self.owner_scene = make_compositor_asset()
+
+    def tearDown(self):
+        remove_compositor_asset(self.node_tree, self.scene, self.owner_scene)
+
+    def test_does_not_write_referenced_scene(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d) / "compositor.blend"
+            result = write_blend_file(out, {self.node_tree})
+            self.assertTrue(result)
+
+            with bpy.data.libraries.load(str(out), link=False) as (src, _dst):
+                scene_names = list(src.scenes)
+
+            self.assertNotIn(self.scene.name, scene_names)
+
+    def test_render_layers_scene_pointer_restored_after_write(self):
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d) / "compositor.blend"
+            write_blend_file(out, {self.node_tree})
+
+            render_layers_node = next(
+                n for n in self.node_tree.nodes if n.bl_idname == 'CompositorNodeRLayers'
+            )
+            self.assertEqual(render_layers_node.scene, self.scene)
+
+
+class TestWriteBlendAllAssetTypes(unittest.TestCase):
+    """Smoke-test write_blend_file against every datablock type the Asset
+    Browser allows marking as an asset (see ASSET_DATABLOCK_COLLECTIONS).
+
+    These are deliberately lightweight — just "does it write without
+    error and produce a real file" — to catch type-specific writer bugs
+    early. Object and NodeTree (compositor) have more thorough dedicated
+    tests elsewhere in this file.
+    """
+
+    def _assert_write_succeeds(self, datablock):
+        with tempfile.TemporaryDirectory() as d:
+            out = Path(d) / "smoke.blend"
+            self.assertTrue(write_blend_file(out, {datablock}))
+            self.assertTrue(out.exists())
+            self.assertGreater(out.stat().st_size, 100)
+
+    def test_material_asset(self):
+        mat = bpy.data.materials.new("QAM_SmokeMaterial")
+        mat.asset_mark()
+        try:
+            self._assert_write_succeeds(mat)
+        finally:
+            bpy.data.materials.remove(mat)
+
+    def test_world_asset(self):
+        world = bpy.data.worlds.new("QAM_SmokeWorld")
+        world.asset_mark()
+        try:
+            self._assert_write_succeeds(world)
+        finally:
+            bpy.data.worlds.remove(world)
+
+    def test_action_asset(self):
+        action = bpy.data.actions.new("QAM_SmokeAction")
+        action.asset_mark()
+        try:
+            self._assert_write_succeeds(action)
+        finally:
+            bpy.data.actions.remove(action)
+
+    def test_armature_asset(self):
+        armature = bpy.data.armatures.new("QAM_SmokeArmature")
+        armature.asset_mark()
+        try:
+            self._assert_write_succeeds(armature)
+        finally:
+            bpy.data.armatures.remove(armature)
+
+    def test_curve_asset(self):
+        curve = bpy.data.curves.new("QAM_SmokeCurve", type='CURVE')
+        curve.asset_mark()
+        try:
+            self._assert_write_succeeds(curve)
+        finally:
+            bpy.data.curves.remove(curve)
+
+    def test_collection_asset(self):
+        collection = bpy.data.collections.new("QAM_SmokeCollection")
+        collection.asset_mark()
+        try:
+            self._assert_write_succeeds(collection)
+        finally:
+            bpy.data.collections.remove(collection)
+
+    def test_mesh_asset(self):
+        mesh = bpy.data.meshes.new("QAM_SmokeMesh")
+        mesh.asset_mark()
+        try:
+            self._assert_write_succeeds(mesh)
+        finally:
+            bpy.data.meshes.remove(mesh)
+
+    def test_brush_asset(self):
+        brush = bpy.data.brushes.new("QAM_SmokeBrush", mode='TEXTURE_PAINT')
+        brush.asset_mark()
+        try:
+            self._assert_write_succeeds(brush)
+        finally:
+            bpy.data.brushes.remove(brush)
+
+    def test_scene_asset(self):
+        # Use a copy of the active scene rather than bpy.data.scenes.new():
+        # a brand-new, never-initialized scene's view layer can be missing
+        # data that some Blender versions' partial-write path dereferences
+        # unconditionally, crashing the process (observed as a native
+        # access violation on 5.2 alpha). A copy of an existing, fully
+        # initialized scene is both safer and more representative of a
+        # real Scene asset a user would actually save.
+        scene = bpy.context.scene.copy()
+        scene.asset_mark()
+        try:
+            self._assert_write_succeeds(scene)
+        finally:
+            bpy.data.scenes.remove(scene)


### PR DESCRIPTION
### New Features

- **Bulk Move & Bundle from Current File**: You can now select multiple unsaved assets directly in your Current File and Move or Bundle them straight to a library, instead of saving them one at a time.
- **Copy Catalog from Current File**: When saving an asset, enable this checkbox to automatically reuse the asset's existing catalog. If that catalog doesn't exist yet in the target library, it's created for you — no need to pick it manually from the dropdown.

### Improvements

- Moving assets now shows a clear confirmation message, so you know right away it worked.
- The Catalog dropdown has a refresh button, so newly created catalogs show up immediately without restarting Blender.
- Disabled asset libraries no longer show up in your library dropdowns. 
- Added a heads-up on the Bundle panel that opening the save-path picker will deselect your assets (a quirk of Blender's file browser).

### Bug Fixes

- Saving an asset to a library no longer removes its catalog from the Current File. 
- Fixed an issue on Blender 5.1+ where the protected Essentials library could accidentally be modified.
- Fixed "Overwrite" mode for Bundling so it actually replaces the existing file instead of always creating a new one.
- Fixed Bulk Move from the Current File incorrectly reporting "no assets selected."
- Fixed the "Saved!" confirmation message appearing in red as if it were an error.
- If your system's recycle bin/trash feature isn't available, you'll now get a clear warning instead of a silent failure.
- Fixed Compositor node group assets copying the entire project into the library file instead of just the node group itself.
- Fixed saving Scene assets with sound/video sequences potentially failing on the newest Blender 5.2 builds.

### Notes
- Blender 5.2 added online asset libraries, which at least for now will not be supported by Quick Asset Manager. All QAM features will not work to or from online asset libraries. This was a conscious decision to avoid the complexity of dealing with online asset libraries, which are not yet fully documented and may change in future Blender releases. Additionally, I'm not entirely sure how licensing and copyright issues will be handled with online asset libraries, so for now QAM will only support local asset libraries.

- While the user-facing changes are relatively minor, the underlying code has had a large refactor to improve maintainability and future feature development. Because of this, testing has been incredibly thorough (including creating over 150 tests to ensure no regressions), but if you notice any issues, please report them on GitHub.

### Issue Closures
This closes #8 
This closes #9 
This closes #10 
This closes #11
This closes #12 
This closes #14 
